### PR TITLE
Added namespace as a member of Remotable and updated example

### DIFF
--- a/examples/tutorials/remote_example.py
+++ b/examples/tutorials/remote_example.py
@@ -59,23 +59,18 @@ async def run_batch(adder_client, send_tensor=False):
 
 
 def main():
-    adder1 = Adder('adder1')
-    adder2 = Adder('adder2')
+    adder = Adder()
     adder_server = Server(name="adder_server", addr="127.0.0.1:4411")
-    adder_server.add_service([adder1, adder2])
+    adder_server.add_service(adder)
 
-    adder_client = remote_utils.make_remote(adder1, adder_server)
-    adder_client2 = remote_utils.make_remote(adder2, adder_server)
+    adder_client = remote_utils.make_remote(adder, adder_server)
 
     adder_server.start()
     adder_client.connect()
-    adder_client2.connect()
 
     a = 1
     b = 2
     c = adder_client.add(a, b)
-    print(f"{a} + {b} = {c}")
-    c = adder_client2.add(a, b)
     print(f"{a} + {b} = {c}")
     print("")
     asyncio.run(run_batch(adder_client, send_tensor=False))

--- a/examples/tutorials/remote_example.py
+++ b/examples/tutorials/remote_example.py
@@ -59,18 +59,23 @@ async def run_batch(adder_client, send_tensor=False):
 
 
 def main():
-    adder = Adder()
+    adder1 = Adder('adder1')
+    adder2 = Adder('adder2')
     adder_server = Server(name="adder_server", addr="127.0.0.1:4411")
-    adder_server.add_service(adder)
+    adder_server.add_service([adder1, adder2])
 
-    adder_client = remote_utils.make_remote(adder, adder_server)
+    adder_client = remote_utils.make_remote(adder1, adder_server)
+    adder_client2 = remote_utils.make_remote(adder2, adder_server)
 
     adder_server.start()
     adder_client.connect()
+    adder_client2.connect()
 
     a = 1
     b = 2
     c = adder_client.add(a, b)
+    print(f"{a} + {b} = {c}")
+    c = adder_client2.add(a, b)
     print(f"{a} + {b} = {c}")
     print("")
     asyncio.run(run_batch(adder_client, send_tensor=False))

--- a/rlmeta/core/controller.py
+++ b/rlmeta/core/controller.py
@@ -19,11 +19,12 @@ class Phase(IntEnum):
 
 class Controller(remote.Remotable):
 
-    def __init__(self) -> None:
+    def __init__(self, identifier: str = "") -> None:
         self._phase = Phase.NONE
         self._count = 0
         self._limit = None
         self._stats = StatsDict()
+        super().__init__(identifier)
 
     @property
     def phase(self) -> Phase:

--- a/rlmeta/core/model.py
+++ b/rlmeta/core/model.py
@@ -16,7 +16,7 @@ from rlmeta.core.server import Server
 
 class RemotableModel(nn.Module, remote.Remotable):
 
-    def __init(self, identifier: str = ""):
+    def __init__(self, identifier: str = ""):
         remote.Remotable.__init__(self, identifier)
 
     def init_launching(self) -> None:

--- a/rlmeta/core/model.py
+++ b/rlmeta/core/model.py
@@ -16,6 +16,9 @@ from rlmeta.core.server import Server
 
 class RemotableModel(nn.Module, remote.Remotable):
 
+    def __init(self, identifier: str = ""):
+        remote.Remotable.__init__(self, identifier)
+
     def init_launching(self) -> None:
         self.share_memory()
 

--- a/rlmeta/core/remote.py
+++ b/rlmeta/core/remote.py
@@ -26,7 +26,6 @@ class RemotableMeta(abc.ABCMeta):
             if getattr(method, "__remote__", False):
                 remote_methods.add(method.__name__)
         attrs["__remote_methods__"] = list(remote_methods)
-        attrs["__identifier__"] = ""
         return super().__new__(cls, name, bases, attrs)
 
 

--- a/rlmeta/core/remote.py
+++ b/rlmeta/core/remote.py
@@ -31,8 +31,9 @@ class RemotableMeta(abc.ABCMeta):
 
 
 class Remotable(abc.ABC, metaclass=RemotableMeta):
-    def __init__(self, identifier=""):
-        self.__identifier__ = identifier
+
+    def __init__(self, identifier: str = ""):
+        self._identifier = identifier
 
     @property
     def remote_methods(self) -> List[str]:
@@ -40,7 +41,7 @@ class Remotable(abc.ABC, metaclass=RemotableMeta):
 
     @property
     def identifier(self) -> str:
-        return self.__identifier__
+        return self._identifier
 
     def unique_name(self, name: str) -> str:
         return self.identifier + "::" + name
@@ -122,9 +123,11 @@ class Remote:
     def _bind(self) -> None:
         for method in self._remote_methods:
             self._client_methods[method] = functools.partial(
-                self.client.sync, self.server_name, self._identifier + "::" + method)
+                self.client.sync, self.server_name,
+                self._identifier + "::" + method)
             self._client_methods["async_" + method] = functools.partial(
-                self.client.async_, self.server_name,  self._identifier + "::" + method)
+                self.client.async_, self.server_name,
+                self._identifier + "::" + method)
 
 
 def remote_method(batch_size: Optional[int] = None) -> Callable[..., Any]:

--- a/rlmeta/core/replay_buffer.py
+++ b/rlmeta/core/replay_buffer.py
@@ -28,12 +28,14 @@ class ReplayBuffer(remote.Remotable, Launchable):
     def __init__(self,
                  capacity: int,
                  collate_fn: Optional[Callable[[Sequence[NestedTensor]],
-                                               NestedTensor]] = None):
+                                               NestedTensor]] = None,
+                 identifier: str = ""):
         self._buffer = CircularBuffer(capacity)
         if collate_fn is not None:
             self._collate_fn = collate_fn
         else:
             self._collate_fn = data_utils.stack_tensors
+        remote.Remotable.__init__(self, identifier)
 
     def __len__(self) -> int:
         return self.size
@@ -99,8 +101,9 @@ class PrioritizedReplayBuffer(ReplayBuffer):
                  eps: float = 1e-8,
                  collate_fn: Optional[Callable[[Sequence[NestedTensor]],
                                                NestedTensor]] = None,
-                 priority_type: np.dtype = np.float32) -> None:
-        super().__init__(capacity, collate_fn)
+                 priority_type: np.dtype = np.float32,
+                 identifier: str = "") -> None:
+        super().__init__(capacity, collate_fn, identifier=identifier)
 
         assert alpha > 0
         assert beta >= 0

--- a/rlmeta/core/server.py
+++ b/rlmeta/core/server.py
@@ -91,7 +91,8 @@ class Server(Launchable):
             for method in service.remote_methods:
                 method_impl = getattr(service, method)
                 batch_size = getattr(method_impl, "__batch_size__", None)
-                self._add_server_task(service.unique_name(method), method_impl, batch_size)
+                self._add_server_task(service.unique_name(method), method_impl,
+                                      batch_size)
         try:
             if not self._loop.is_running():
                 self._loop.run_forever()

--- a/rlmeta/core/server.py
+++ b/rlmeta/core/server.py
@@ -91,7 +91,7 @@ class Server(Launchable):
             for method in service.remote_methods:
                 method_impl = getattr(service, method)
                 batch_size = getattr(method_impl, "__batch_size__", None)
-                self._add_server_task(method, method_impl, batch_size)
+                self._add_server_task(service.unique_name(method), method_impl, batch_size)
         try:
             if not self._loop.is_running():
                 self._loop.run_forever()

--- a/tests/core/remotable_test.py
+++ b/tests/core/remotable_test.py
@@ -22,17 +22,6 @@ class RemotableAdder(remote.Remotable):
 
 class ReplayBufferTest(unittest.TestCase):
 
-    # def test_add(self):
-    #     server = Server(name="adder_server", addr="127.0.0.1:4411")
-    #     adder = RemotableAdder()
-    #     server.add_service(adder)
-    #     adder_client = remote_utils.make_remote(adder, server)
-    #     server.start()
-    #     adder_client.connect()
-    #     c = adder_client.add(1, 1)
-    #     self.assertEqual(c, 2)
-    #     server.terminate()
-
     def test_add_multiple(self):
         server = Server(name="adder_server", addr="127.0.0.1:4412")
         adder1 = RemotableAdder('a')
@@ -50,6 +39,7 @@ class ReplayBufferTest(unittest.TestCase):
         c = adder_client2.add(1, 1)
         self.assertEqual(c, 2)
         server.terminate()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/remotable_test.py
+++ b/tests/core/remotable_test.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import numpy as np
+import torch
+
+import rlmeta.core.remote as remote
+import rlmeta.utils.remote_utils as remote_utils
+from rlmeta.core.server import Server
+
+
+class RemotableAdder(remote.Remotable):
+
+    @remote.remote_method()
+    def add(self, a, b):
+        return a + b
+
+
+class ReplayBufferTest(unittest.TestCase):
+
+    def setUp(self):
+        self.server = Server(name="adder_server", addr="127.0.0.1:4411")
+
+    def tearDown(self) -> None:
+        self.server.terminate()
+
+    def test_add(self):
+        adder = RemotableAdder()
+        self.server.add_service(adder)
+        adder_client = remote_utils.make_remote(adder, self.server)
+        self.server.start()
+        adder_client.connect()
+        c = adder_client.add(1, 1)
+        self.assertEqual(c, 2)
+
+    def test_add_multiple(self):
+        adder1 = RemotableAdder('1')
+        adder2 = RemotableAdder('2')
+        self.server.add_service([adder1, adder2])
+        adder_client1 = remote_utils.make_remote(adder1, self.server)
+        adder_client2 = remote_utils.make_remote(adder2, self.server)
+        self.server.start()
+        adder_client1.connect()
+        self.assertEqual(adder_client1.add(1, 1), 2)
+        adder_client2.connect()
+        self.assertEqual(adder_client2.add(1, 1), 2)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/remotable_test.py
+++ b/tests/core/remotable_test.py
@@ -22,32 +22,34 @@ class RemotableAdder(remote.Remotable):
 
 class ReplayBufferTest(unittest.TestCase):
 
-    def setUp(self):
-        self.server = Server(name="adder_server", addr="127.0.0.1:4411")
-
-    def tearDown(self) -> None:
-        self.server.terminate()
-
-    def test_add(self):
-        adder = RemotableAdder()
-        self.server.add_service(adder)
-        adder_client = remote_utils.make_remote(adder, self.server)
-        self.server.start()
-        adder_client.connect()
-        c = adder_client.add(1, 1)
-        self.assertEqual(c, 2)
+    # def test_add(self):
+    #     server = Server(name="adder_server", addr="127.0.0.1:4411")
+    #     adder = RemotableAdder()
+    #     server.add_service(adder)
+    #     adder_client = remote_utils.make_remote(adder, server)
+    #     server.start()
+    #     adder_client.connect()
+    #     c = adder_client.add(1, 1)
+    #     self.assertEqual(c, 2)
+    #     server.terminate()
 
     def test_add_multiple(self):
-        adder1 = RemotableAdder('1')
-        adder2 = RemotableAdder('2')
-        self.server.add_service([adder1, adder2])
-        adder_client1 = remote_utils.make_remote(adder1, self.server)
-        adder_client2 = remote_utils.make_remote(adder2, self.server)
-        self.server.start()
+        server = Server(name="adder_server", addr="127.0.0.1:4412")
+        adder1 = RemotableAdder('a')
+        adder2 = RemotableAdder('b')
+        self.assertEqual(adder1.identifier, 'a')
+        self.assertEqual(adder2.identifier, 'b')
+        server.add_service([adder1, adder2])
+        adder_client1 = remote_utils.make_remote(adder1, server)
+        adder_client2 = remote_utils.make_remote(adder2, server)
+        server.start()
         adder_client1.connect()
-        self.assertEqual(adder_client1.add(1, 1), 2)
+        c = adder_client1.add(1, 1)
+        self.assertEqual(c, 2)
         adder_client2.connect()
-        self.assertEqual(adder_client2.add(1, 1), 2)
+        c = adder_client2.add(1, 1)
+        self.assertEqual(c, 2)
+        server.terminate()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added an identifier for remotable class, this allows distinguish instances of the same class/different class sharing the same method as long as user defines a method. 

Alternatively or additionally, we can also add the func name to the identifier to further distinguish between different instantiated classes with the same name. for example PPOAgent.forward() and APPOAgent.forward() wouldn't need an identifier additionally. 