### PR TITLE
Add more logging + ability to push to more downstream models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy
 opencv-python
 tabulate
 torch>=1.5.1
+rich

--- a/rlmeta/core/controller.py
+++ b/rlmeta/core/controller.py
@@ -25,6 +25,9 @@ class Controller(remote.Remotable):
         self._limit = None
         self._stats = StatsDict()
 
+    def __repr__(self):
+        return f'Controller(phase={self._phase})'
+
     @property
     def phase(self) -> Phase:
         return self._phase

--- a/rlmeta/core/loop.py
+++ b/rlmeta/core/loop.py
@@ -11,6 +11,7 @@ import logging
 import time
 
 from typing import Dict, List, NoReturn, Optional, Sequence, Union
+from rich.console import Console
 
 import torch
 import torch.multiprocessing as mp
@@ -25,6 +26,8 @@ from rlmeta.agents.agent import Agent, AgentFactory
 from rlmeta.core.controller import Controller, ControllerLike, Phase
 from rlmeta.core.launchable import Launchable
 from rlmeta.envs.env import Env, EnvFactory
+
+console = Console()
 
 
 class Loop(abc.ABC):
@@ -128,6 +131,7 @@ class AsyncLoop(Loop, Launchable):
                 obj.init_execution()
 
     def run(self) -> NoReturn:
+        console.log(f"Starting async loop with: {self._controller}")
         self._loop = asyncio.get_event_loop()
         self._tasks.append(
             asycio_utils.create_task(self._loop, self._check_phase()))

--- a/rlmeta/core/remote.py
+++ b/rlmeta/core/remote.py
@@ -44,6 +44,10 @@ class Remote:
                  server_addr: str,
                  name: Optional[str] = None,
                  timeout: float = 60) -> None:
+        self._target = target
+        self._server_name = server_name
+        self._server_addr = server_addr
+
         self._remote_methods = target.remote_methods
         self._reset(server_name, server_addr, name, timeout)
         self._client_methods = {}
@@ -57,6 +61,9 @@ class Remote:
             if ret is not None:
                 return ret
             raise
+
+    def __repr__(self):
+        return f'Remote(target={self._target} server_name={self._server_name} server_addr={self._server_addr})'
 
     @property
     def name(self) -> str:

--- a/rlmeta/core/replay_buffer.py
+++ b/rlmeta/core/replay_buffer.py
@@ -8,7 +8,7 @@ import time
 import logging
 
 from typing import Callable, Optional, Sequence, Tuple, Union
-
+from rich.console import Console
 import numpy as np
 import torch
 
@@ -21,6 +21,8 @@ from rlmeta.core.segment_tree import SumSegmentTree, MinSegmentTree
 from rlmeta.core.server import Server
 from rlmeta.core.types import Tensor, NestedTensor
 from rlmeta_extension import CircularBuffer
+
+console = Console()
 
 
 class ReplayBuffer(remote.Remotable, Launchable):
@@ -260,6 +262,11 @@ class RemoteReplayBuffer(remote.Remote):
         super().__init__(target, server_name, server_addr, name, timeout)
         self._prefetch = prefetch
         self._futures = collections.deque()
+        self._server_name = server_name
+        self._server_addr = server_addr
+
+    def __repr__(self):
+        return f'RemoteReplayBuffer(server_name={self._server_name}, server_addr={self._server_addr})'
 
     @property
     def prefetch(self) -> Optional[int]:
@@ -304,8 +311,8 @@ class RemoteReplayBuffer(remote.Remote):
         while cur_size < target_size:
             time.sleep(1)
             cur_size = self.get_size()
-            logging.info("Warming up replay buffer: " +
-                         f"[{cur_size: {width}d} / {capacity} ]")
+            console.log("Warming up replay buffer: " +
+                        f"[{cur_size: {width}d} / {capacity} ]")
 
 
 ReplayBufferLike = Union[ReplayBuffer, RemoteReplayBuffer]


### PR DESCRIPTION
This PR adds:
* repr functions for some classes
* Rich based logging: https://rich.readthedocs.io/en/stable/introduction.html
* Extra parameter `additional_downstream_models` to `agent.train` that can be used to push to more than one downstream model (e.g., if there are multiple parallel loops, push to the model that each loop is using).