### PR TITLE
Fix bugs in ApeX DQN

### DIFF
--- a/rlmeta/CMakeLists.txt
+++ b/rlmeta/CMakeLists.txt
@@ -50,9 +50,10 @@ add_subdirectory(
 
 pybind11_add_module(
   _rlmeta_extension
-  ${CMAKE_CURRENT_SOURCE_DIR}/cc/pybind.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/cc/circular_buffer.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/cc/nested_utils.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/cc/pybind.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/cc/timestamp_manager.cc
 )
 target_include_directories(
   _rlmeta_extension PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)

--- a/rlmeta/agents/agent.py
+++ b/rlmeta/agents/agent.py
@@ -19,6 +19,9 @@ from rlmeta.utils.stats_dict import StatsDict
 
 class Agent(abc.ABC):
 
+    def reset(self) -> None:
+        pass
+
     def act(self, timestep: TimeStep) -> Action:
         """
         Act function.

--- a/rlmeta/cc/circular_buffer.h
+++ b/rlmeta/cc/circular_buffer.h
@@ -18,7 +18,7 @@ namespace rlmeta {
 
 class CircularBuffer {
  public:
-  CircularBuffer(int64_t capacity) : capacity_(capacity) { Reset(); }
+  explicit CircularBuffer(int64_t capacity) : capacity_(capacity) { Reset(); }
 
   int64_t capacity() const { return capacity_; }
 

--- a/rlmeta/cc/pybind.cc
+++ b/rlmeta/cc/pybind.cc
@@ -8,6 +8,7 @@
 #include "rlmeta/cc/circular_buffer.h"
 #include "rlmeta/cc/nested_utils.h"
 #include "rlmeta/cc/segment_tree.h"
+#include "rlmeta/cc/timestamp_manager.h"
 
 namespace py = pybind11;
 
@@ -16,13 +17,12 @@ namespace {
 PYBIND11_MODULE(_rlmeta_extension, m) {
   rlmeta::DefineSumSegmentTree<float>("Fp32", m);
   rlmeta::DefineSumSegmentTree<double>("Fp64", m);
-
   rlmeta::DefineMinSegmentTree<float>("Fp32", m);
   rlmeta::DefineMinSegmentTree<double>("Fp64", m);
 
   rlmeta::DefineCircularBuffer(m);
-
   rlmeta::DefineNestedUtils(m);
+  rlmeta::DefineTimestampManager(m);
 }
 
 }  // namespace

--- a/rlmeta/cc/segment_tree.h
+++ b/rlmeta/cc/segment_tree.h
@@ -48,7 +48,7 @@ class SegmentTree {
  public:
   SegmentTree(int64_t size, const T& identity_element)
       : size_(size), identity_element_(identity_element) {
-    for (capacity_ = 1; capacity_ < size; capacity_ <<= 1)
+    for (capacity_ = 1; capacity_ <= size; capacity_ <<= 1)
       ;
     values_.assign(2 * capacity_, identity_element_);
   }

--- a/rlmeta/cc/timestamp_manager.cc
+++ b/rlmeta/cc/timestamp_manager.cc
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "rlmeta/cc/timestamp_manager.h"
+
+#include <memory>
+
+namespace rlmeta {
+
+void TimestampManager::BatchAtImpl(int64_t n, const int64_t* index,
+                                   int64_t* timestamp) const {
+  for (int64_t i = 0; i < n; ++i) {
+    timestamp[i] = timestamps_[index[i]];
+  }
+}
+
+void TimestampManager::BatchIsAvailableImpl(int64_t n, const int64_t* index,
+                                            const int64_t* timestamp,
+                                            bool* mask) const {
+  for (int64_t i = 0; i < n; ++i) {
+    mask[i] = (timestamp[i] == timestamps_[index[i]]);
+  }
+}
+
+void TimestampManager::BatchUpdateImpl(int64_t n, const int64_t* index) {
+  for (int64_t i = 0; i < n; ++i) {
+    timestamps_[index[i]] = current_timestamp_;
+  }
+  ++current_timestamp_;
+}
+
+void TimestampManager::BatchUpdateImpl(int64_t n, const int64_t* index,
+                                       const bool* mask) {
+  for (int64_t i = 0; i < n; ++i) {
+    if (mask[i]) {
+      timestamps_[index[i]] = current_timestamp_;
+    }
+  }
+  ++current_timestamp_;
+}
+
+void DefineTimestampManager(py::module& m) {
+  py::class_<TimestampManager, std::shared_ptr<TimestampManager>>(
+      m, "TimestampManager")
+      .def(py::init<int64_t>())
+      .def_property_readonly("size", &TimestampManager::size)
+      .def_property_readonly("current_timestamp",
+                             &TimestampManager::current_timestamp)
+      .def("__len__", &TimestampManager::size)
+      .def("__getitem__",
+           py::overload_cast<int64_t>(&TimestampManager::At, py::const_))
+      .def("__getitem__", py::overload_cast<const py::array_t<int64_t>&>(
+                              &TimestampManager::At, py::const_))
+      .def("__getitem__", py::overload_cast<const torch::Tensor&>(
+                              &TimestampManager::At, py::const_))
+      .def("at", py::overload_cast<int64_t>(&TimestampManager::At, py::const_))
+      .def("at", py::overload_cast<const py::array_t<int64_t>&>(
+                     &TimestampManager::At, py::const_))
+      .def("at", py::overload_cast<const torch::Tensor&>(&TimestampManager::At,
+                                                         py::const_))
+      .def("is_available", py::overload_cast<int64_t, int64_t>(
+                               &TimestampManager::IsAvailable, py::const_))
+      .def("is_available", py::overload_cast<const py::array_t<int64_t>&,
+                                             const py::array_t<int64_t>&>(
+                               &TimestampManager::IsAvailable, py::const_))
+      .def("is_available",
+           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
+               &TimestampManager::IsAvailable, py::const_))
+      .def("update", py::overload_cast<int64_t>(&TimestampManager::Update))
+      .def("update", py::overload_cast<const py::array_t<int64_t>&>(
+                         &TimestampManager::Update))
+      .def("update",
+           py::overload_cast<const torch::Tensor&>(&TimestampManager::Update))
+      .def("update", py::overload_cast<const py::array_t<int64_t>&,
+                                       const py::array_t<bool>&>(
+                         &TimestampManager::Update))
+      .def("update",
+           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
+               &TimestampManager::Update))
+      .def(py::pickle(
+          [](const TimestampManager& m) {
+            return py::make_tuple(m.Numpy(), m.current_timestamp());
+          },
+          [](const py::tuple& t) {
+            assert(t.size() == 2);
+            const py::array_t<int64_t> data = t[0].cast<py::array_t<int64_t>>();
+            const int64_t current_timestamp = t[1].cast<int64_t>();
+            TimestampManager timestamps;
+            timestamps.LoadData(data, current_timestamp);
+            return timestamps;
+          }));
+}
+
+}  // namespace rlmeta

--- a/rlmeta/cc/timestamp_manager.h
+++ b/rlmeta/cc/timestamp_manager.h
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <torch/extension.h>
+#include <torch/torch.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "rlmeta/cc/numpy_utils.h"
+#include "rlmeta/cc/torch_utils.h"
+
+namespace rlmeta {
+
+class TimestampManager {
+ public:
+  TimestampManager() = default;
+  explicit TimestampManager(int64_t size) : size_(size) { Reset(); }
+
+  int64_t size() const { return size_; }
+
+  int64_t current_timestamp() const { return current_timestamp_; }
+
+  void Reset() {
+    timestamps_.assign(size_, -1);
+    current_timestamp_ = 0;
+  }
+
+  void Reset(int64_t size) {
+    size_ = size;
+    timestamps_.assign(size_, -1);
+    current_timestamp_ = 0;
+  }
+
+  int64_t At(int64_t index) const { return timestamps_[index]; }
+
+  py::array_t<int64_t> At(const py::array_t<int64_t>& index) const {
+    py::array_t<int64_t> timestamp =
+        utils::NumpyEmptyLike<int64_t, int64_t>(index);
+    BatchAtImpl(index.size(), index.data(), timestamp.mutable_data());
+    return timestamp;
+  }
+
+  torch::Tensor At(const torch::Tensor& index) const {
+    assert(index.dtype() == torch::kInt64);
+    const torch::Tensor index_contiguous = index.contiguous();
+    const int64_t n = index_contiguous.numel();
+    torch::Tensor timestamp = torch::empty_like(index_contiguous);
+    BatchAtImpl(n, index_contiguous.data_ptr<int64_t>(),
+                timestamp.data_ptr<int64_t>());
+    return timestamp;
+  }
+
+  py::array_t<int64_t> Numpy() const {
+    py::array_t<int64_t> arr(size_);
+    std::memcpy(arr.mutable_data(), timestamps_.data(),
+                size_ * sizeof(int64_t));
+    return arr;
+  }
+
+  bool IsAvailable(int64_t index, int64_t timestamp) const {
+    return timestamps_[index] == timestamp;
+  }
+
+  py::array_t<bool> IsAvailable(const py::array_t<int64_t>& index,
+                                const py::array_t<int64_t>& timestamp) const {
+    py::array_t<bool> mask = utils::NumpyEmptyLike<int64_t, bool>(index);
+    BatchIsAvailableImpl(index.size(), index.data(), timestamp.data(),
+                         mask.mutable_data());
+    return mask;
+  }
+
+  torch::Tensor IsAvailable(const torch::Tensor& index,
+                            const torch::Tensor& timestamp) const {
+    assert(index.dtype() == torch::kInt64);
+    assert(timestamp.dtype() == torch::kInt64);
+    const torch::Tensor index_contiguous = index.contiguous();
+    const torch::Tensor timestamp_contiguous = timestamp.contiguous();
+    const int64_t n = index_contiguous.numel();
+    torch::Tensor mask =
+        torch::empty_like(index_contiguous, utils::TorchDataType<bool>::value);
+    BatchIsAvailableImpl(n, index_contiguous.data_ptr<int64_t>(),
+                         timestamp_contiguous.data_ptr<int64_t>(),
+                         mask.data_ptr<bool>());
+    return mask;
+  }
+
+  void Update(int64_t index) { timestamps_[index] = current_timestamp_++; }
+
+  void Update(const py::array_t<int64_t>& index) {
+    BatchUpdateImpl(index.size(), index.data());
+  }
+
+  void Update(const py::array_t<int64_t>& index,
+              const py::array_t<bool>& mask) {
+    BatchUpdateImpl(index.size(), index.data(), mask.data());
+  }
+
+  void Update(const torch::Tensor& index) {
+    assert(index.dtype() == torch::kInt64);
+    const torch::Tensor index_contiguous = index.contiguous();
+    BatchUpdateImpl(index_contiguous.numel(),
+                    index_contiguous.data_ptr<int64_t>());
+  }
+
+  void Update(const torch::Tensor& index, const torch::Tensor& mask) {
+    assert(index.dtype() == torch::kInt64);
+    assert(mask.dtype() == torch::kBool);
+    const torch::Tensor index_contiguous = index.contiguous();
+    const torch::Tensor mask_contiguous = mask.contiguous();
+    BatchUpdateImpl(index_contiguous.numel(),
+                    index_contiguous.data_ptr<int64_t>(),
+                    mask_contiguous.data_ptr<bool>());
+  }
+
+  void LoadData(const py::array_t<int64_t>& data, int64_t current_timestamp) {
+    size_ = data.size();
+    timestamps_.resize(size_);
+    std::memcpy(timestamps_.data(), data.data(), size_ * sizeof(int64_t));
+    current_timestamp_ = current_timestamp;
+  }
+
+ protected:
+  void BatchAtImpl(int64_t n, const int64_t* index, int64_t* timestamp) const;
+
+  void BatchIsAvailableImpl(int64_t n, const int64_t* index,
+                            const int64_t* timestamp, bool* mask) const;
+
+  void BatchUpdateImpl(int64_t n, const int64_t* index);
+  void BatchUpdateImpl(int64_t n, const int64_t* index, const bool* mask);
+
+  int64_t size_;
+  std::vector<int64_t> timestamps_;
+  int64_t current_timestamp_;
+};
+
+void DefineTimestampManager(py::module& m);
+
+}  // namespace rlmeta

--- a/rlmeta/cc/torch_utils.h
+++ b/rlmeta/cc/torch_utils.h
@@ -16,6 +16,11 @@ template <typename T>
 struct TorchDataType;
 
 template <>
+struct TorchDataType<bool> {
+  static constexpr torch::ScalarType value = torch::kBool;
+};
+
+template <>
 struct TorchDataType<int64_t> {
   static constexpr torch::ScalarType value = torch::kInt64;
 };

--- a/rlmeta/core/remote.py
+++ b/rlmeta/core/remote.py
@@ -117,6 +117,7 @@ class Remote:
         if self._connected:
             return
         self._client = moolib.Rpc()
+        self._client.set_transports(["uv"])
         self._client.set_name(self._name)
         self._client.set_timeout(self._timeout)
         self._client.connect(self._server_addr)

--- a/rlmeta/core/server.py
+++ b/rlmeta/core/server.py
@@ -86,6 +86,7 @@ class Server(Launchable):
                 service.init_execution()
 
         self._server = moolib.Rpc()
+        self._server.set_transports(["uv"])
         self._server.set_name(self._name)
         self._server.set_timeout(self._timeout)
         console.log(f"Server={self.name} listening to {self._addr}")

--- a/rlmeta/data/__init__.py
+++ b/rlmeta/data/__init__.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from _rlmeta_extension import CircularBuffer
+from _rlmeta_extension import TimestampManager
 from rlmeta.data.segment_tree import SumSegmentTree, MinSegmentTree
 
 __all__ = [

--- a/rlmeta/data/segment_tree.py
+++ b/rlmeta/data/segment_tree.py
@@ -3,13 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
 
 from _rlmeta_extension import (SumSegmentTreeFp32, SumSegmentTreeFp64,
                                MinSegmentTreeFp32, MinSegmentTreeFp64)
+from rlmeta.core.types import Tensor
 
 SegmentTreeImpl = Union[SumSegmentTreeFp32, SumSegmentTreeFp64,
                         MinSegmentTreeFp32, MinSegmentTreeFp64]
@@ -49,8 +50,14 @@ class SegmentTree:
     def __setitem__(self, index: Index, value: Value) -> None:
         self._impl[index] = value
 
-    def update(self, index: Index, value: Value) -> None:
-        self._impl.update(index, value)
+    def update(self,
+               index: Index,
+               value: Value,
+               mask: Optional[Tensor] = None) -> None:
+        if mask is None:
+            self._impl.update(index, value)
+        else:
+            self._impl.update(index, value, mask)
 
     def query(self, l: Index, r: Index) -> Value:
         return self._impl.query(l, r)

--- a/tests/data/segment_tree_test.py
+++ b/tests/data/segment_tree_test.py
@@ -64,6 +64,26 @@ class SumSegmentTreeTest(TestCaseBase):
         self.assert_tensor_equal(self.segment_tree[index], value)
         self.segment_tree[index] = origin_value
 
+    def test_masked_update(self) -> None:
+        weights = torch.ones(self.size)
+        index = weights.multinomial(prod(self.query_size), replacement=False)
+        index = index.view(self.query_size)
+        origin_value = self.segment_tree[index]
+        mask = torch.randint(2, size=self.query_size, dtype=torch.bool)
+
+        value = np.random.randn()
+        self.segment_tree.update(index, value, mask)
+        self.assert_tensor_equal(
+            self.segment_tree[index],
+            torch.where(mask, torch.full(self.query_size, value), origin_value))
+        self.segment_tree[index] = origin_value
+
+        value = torch.randn(self.query_size)
+        self.segment_tree.update(index, value, mask)
+        self.assert_tensor_equal(self.segment_tree[index],
+                                 torch.where(mask, value, origin_value))
+        self.segment_tree[index] = origin_value
+
     def test_query(self) -> None:
         a = torch.randint(self.size, self.query_size)
         b = torch.randint(self.size, self.query_size)


### PR DESCRIPTION
This PR fixed several issues in ApeX-DQN
1. Add global step_counter so control target_net sync frequency.
2. Fix a bug in SegmentTree when the size is exactly 2^n