### PR TITLE
Separate C++ and Python APIs for SegmentTree

### DIFF
--- a/rlmeta/cc/pybind.cc
+++ b/rlmeta/cc/pybind.cc
@@ -7,7 +7,7 @@
 
 #include "rlmeta/cc/circular_buffer.h"
 #include "rlmeta/cc/nested_utils.h"
-#include "rlmeta/cc/segment_tree.h"
+#include "rlmeta/cc/segment_tree_pybind.h"
 #include "rlmeta/cc/timestamp_manager.h"
 
 namespace py = pybind11;
@@ -17,8 +17,6 @@ namespace {
 PYBIND11_MODULE(_rlmeta_extension, m) {
   rlmeta::DefineSumSegmentTree<float>("Fp32", m);
   rlmeta::DefineSumSegmentTree<double>("Fp64", m);
-  rlmeta::DefineMinSegmentTree<float>("Fp32", m);
-  rlmeta::DefineMinSegmentTree<double>("Fp64", m);
 
   rlmeta::DefineCircularBuffer(m);
   rlmeta::DefineNestedUtils(m);

--- a/rlmeta/cc/segment_tree.h
+++ b/rlmeta/cc/segment_tree.h
@@ -5,21 +5,12 @@
 
 #pragma once
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <torch/extension.h>
-#include <torch/torch.h>
-
 #include <cassert>
 #include <cstdint>
+#include <cstring>
 #include <functional>
-#include <limits>
+#include <iterator>
 #include <vector>
-
-#include "rlmeta/cc/numpy_utils.h"
-#include "rlmeta/cc/torch_utils.h"
-
-namespace py = pybind11;
 
 namespace rlmeta {
 
@@ -46,128 +37,65 @@ namespace rlmeta {
 template <typename T, class Operator>
 class SegmentTree {
  public:
-  SegmentTree(int64_t size, const T& identity_element)
-      : size_(size), identity_element_(identity_element) {
-    for (capacity_ = 1; capacity_ <= size; capacity_ <<= 1)
-      ;
-    values_.assign(2 * capacity_, identity_element_);
+  SegmentTree(int64_t size, T identity_element)
+      : size_(size),
+        capacity_(Capacity(size_)),
+        identity_element_(identity_element),
+        values_(2 * capacity_, identity_element_) {}
+
+  template <class InputIterator>
+  SegmentTree(InputIterator first, InputIterator last, T identity_element)
+      : size_(std::distance(first, last)),
+        capacity_(Capacity(size_)),
+        identity_element_(identity_element),
+        values_(2 * capacity_, identity_element_) {
+    std::copy(first, last, values_.begin() + capacity_);
+    InitInternal();
   }
 
   int64_t size() const { return size_; }
 
   int64_t capacity() const { return capacity_; }
 
-  const T& identity_element() const { return identity_element_; }
+  T identity_element() const { return identity_element_; }
 
-  const T& At(int64_t index) const { return values_[index | capacity_]; }
+  T At(int64_t index) const { return values_[index | capacity_]; }
 
-  py::array_t<T> At(const py::array_t<int64_t>& index) const {
-    py::array_t<T> value = utils::NumpyEmptyLike<int64_t, T>(index);
-    BatchAtImpl(index.size(), index.data(), value.mutable_data());
-    return value;
+  void Resize(int64_t size) {
+    if (size < size_) {
+      std::fill(values_.data() + capacity_ + size,
+                values_.data() + capacity_ + size_, identity_element_);
+      InitInternal();
+    } else if (size > size_) {
+      const int64_t cap = Capacity(size);
+      if (cap > capacity_) {
+        values_.resize(2 * cap, identity_element_);
+        std::memcpy(values_.data() + cap, values_.data() + capacity_,
+                    size_ * sizeof(T));
+        capacity_ = cap;
+        InitInternal();
+      }
+    }
+    size_ = size;
   }
 
-  torch::Tensor At(const torch::Tensor& index) const {
-    assert(index.dtype() == torch::kInt64);
-    const torch::Tensor index_contiguous = index.contiguous();
-    const int64_t n = index_contiguous.numel();
-    torch::Tensor value =
-        torch::empty_like(index_contiguous, utils::TorchDataType<T>::value);
-    BatchAtImpl(n, index_contiguous.data_ptr<int64_t>(), value.data_ptr<T>());
-    return value;
+  void ShrinkToFit() {
+    const int64_t cap = Capacity(size_);
+    if (cap < capacity_) {
+      std::memcpy(values_.data() + cap, values_.data() + capacity_,
+                  size_ * sizeof(T));
+      capacity_ = cap;
+      InitInternal();
+      values_.resize(2 * capacity_);
+    }
   }
 
   // Update the item at index to value.
   // Time complexity: O(logN).
-  void Update(int64_t index, const T& value) {
+  void Update(int64_t index, T value) {
     index |= capacity_;
     for (values_[index] = value; index > 1; index >>= 1) {
       values_[index >> 1] = op_(values_[index], values_[index ^ 1]);
-    }
-  }
-
-  void Update(const py::array_t<int64_t>& index, const T& value) {
-    BatchUpdateImpl(index.size(), index.data(), value);
-  }
-
-  void Update(const py::array_t<int64_t>& index, const py::array_t<T>& value) {
-    assert(value.size() == 1 || index.size() == value.size());
-    const int64_t n = index.size();
-    if (value.size() == 1) {
-      BatchUpdateImpl(n, index.data(), *(value.data()));
-    } else {
-      BatchUpdateImpl(n, index.data(), value.data());
-    }
-  }
-
-  void Update(const py::array_t<int64_t>& index, const T& value,
-              const py::array_t<bool>& mask) {
-    BatchUpdateImpl(index.size(), index.data(), value, mask.data());
-  }
-
-  void Update(const py::array_t<int64_t>& index, const py::array_t<T>& value,
-              const py::array_t<bool>& mask) {
-    assert(value.size() == 1 || index.size() == value.size());
-    const int64_t n = index.size();
-    if (value.size() == 1) {
-      BatchUpdateImpl(n, index.data(), *(value.data()), mask.data());
-    } else {
-      BatchUpdateImpl(n, index.data(), value.data(), mask.data());
-    }
-  }
-
-  void Update(const torch::Tensor& index, const T& value) {
-    assert(index.dtype() == torch::kInt64);
-    const torch::Tensor index_contiguous = index.contiguous();
-    const int64_t n = index_contiguous.numel();
-    BatchUpdateImpl(n, index_contiguous.data_ptr<int64_t>(), value);
-  }
-
-  void Update(const torch::Tensor& index, const torch::Tensor& value) {
-    assert(index.dtype() == torch::kInt64);
-    assert(value.dtype() == utils::TorchDataType<T>::value);
-    assert(value.numel() == 1 || index.sizes() == value.sizes());
-    const torch::Tensor index_contiguous = index.contiguous();
-    const torch::Tensor value_contiguous = value.contiguous();
-    const int64_t n = index_contiguous.numel();
-    if (value_contiguous.numel() == 1) {
-      BatchUpdateImpl(n, index_contiguous.data_ptr<int64_t>(),
-                      *(value_contiguous.data_ptr<T>()));
-    } else {
-      BatchUpdateImpl(n, index_contiguous.data_ptr<int64_t>(),
-                      value_contiguous.data_ptr<T>());
-    }
-  }
-
-  void Update(const torch::Tensor& index, const T& value,
-              const torch::Tensor& mask) {
-    assert(index.dtype() == torch::kInt64);
-    assert(mask.dtype() == torch::kBool);
-    const torch::Tensor index_contiguous = index.contiguous();
-    const torch::Tensor mask_contiguous = mask.contiguous();
-    const int64_t n = index_contiguous.numel();
-    BatchUpdateImpl(n, index_contiguous.data_ptr<int64_t>(), value,
-                    mask_contiguous.data_ptr<bool>());
-  }
-
-  void Update(const torch::Tensor& index, const torch::Tensor& value,
-              const torch::Tensor& mask) {
-    assert(index.dtype() == torch::kInt64);
-    assert(value.dtype() == utils::TorchDataType<T>::value);
-    assert(value.numel() == 1 || index.sizes() == value.sizes());
-    assert(mask.dtype() == torch::kBool);
-    const torch::Tensor index_contiguous = index.contiguous();
-    const torch::Tensor value_contiguous = value.contiguous();
-    const torch::Tensor mask_contiguous = mask.contiguous();
-    const int64_t n = index_contiguous.numel();
-    if (value_contiguous.numel() == 1) {
-      BatchUpdateImpl(n, index_contiguous.data_ptr<int64_t>(),
-                      *(value_contiguous.data_ptr<T>()),
-                      mask_contiguous.data_ptr<bool>());
-    } else {
-      BatchUpdateImpl(n, index_contiguous.data_ptr<int64_t>(),
-                      value_contiguous.data_ptr<T>(),
-                      mask_contiguous.data_ptr<bool>());
     }
   }
 
@@ -194,88 +122,22 @@ class SegmentTree {
     return ret;
   }
 
-  py::array_t<T> Query(const py::array_t<int64_t>& l,
-                       const py::array_t<int64_t>& r) const {
-    py::array_t<T> ret = utils::NumpyEmptyLike<int64_t, T>(l);
-    BatchQueryImpl(l.size(), l.data(), r.data(), ret.mutable_data());
-    return ret;
-  }
-
-  torch::Tensor Query(const torch::Tensor& l, const torch::Tensor& r) const {
-    assert(l.dtype() == torch::kInt64);
-    assert(r.dtype() == torch::kInt64);
-    assert(l.sizes() == r.sizes());
-    const torch::Tensor l_contiguous = l.contiguous();
-    const torch::Tensor r_contiguous = r.contiguous();
-    torch::Tensor ret =
-        torch::empty_like(l_contiguous, utils::TorchDataType<T>::value);
-    const int64_t n = l_contiguous.numel();
-    BatchQueryImpl(n, l_contiguous.data_ptr<int64_t>(),
-                   r_contiguous.data_ptr<int64_t>(), ret.data_ptr<T>());
-    return ret;
-  }
-
-  py::array_t<T> DumpValues() const {
-    py::array_t<T> ret(size_);
-    std::memcpy(ret.mutable_data(), values_.data() + capacity_,
-                size_ * sizeof(T));
-    return ret;
-  }
-
-  void LoadValues(const py::array_t<T>& values) {
-    assert(values.size() == size_);
-    std::memcpy(values_.data() + capacity_, values.data(), size_ * sizeof(T));
-    for (int64_t i = capacity_ - 1; i > 0; --i) {
-      values_[i] = op_(values_[(i << 1)], values_[(i << 1) | 1]);
-    }
-  }
-
  protected:
-  void BatchAtImpl(int64_t n, const int64_t* index, T* value) const {
-    for (int64_t i = 0; i < n; ++i) {
-      value[i] = values_[index[i] | capacity_];
-    }
+  int64_t Capacity(int64_t size) const {
+    int64_t ret = 1;
+    for (; ret <= size; ret <<= 1)
+      ;
+    return ret;
   }
 
-  void BatchUpdateImpl(int64_t n, const int64_t* index, const T& value) {
-    for (int64_t i = 0; i < n; ++i) {
-      Update(index[i], value);
-    }
-  }
-
-  void BatchUpdateImpl(int64_t n, const int64_t* index, const T& value,
-                       const bool* mask) {
-    for (int64_t i = 0; i < n; ++i) {
-      if (mask[i]) {
-        Update(index[i], value);
-      }
-    }
-  }
-
-  void BatchUpdateImpl(int64_t n, const int64_t* index, const T* value) {
-    for (int64_t i = 0; i < n; ++i) {
-      Update(index[i], value[i]);
-    }
-  }
-
-  void BatchUpdateImpl(int64_t n, const int64_t* index, const T* value,
-                       const bool* mask) {
-    for (int64_t i = 0; i < n; ++i) {
-      if (mask[i]) {
-        Update(index[i], value[i]);
-      }
-    }
-  }
-
-  void BatchQueryImpl(int64_t n, const int64_t* l, const int64_t* r,
-                      T* result) const {
-    for (int64_t i = 0; i < n; ++i) {
-      result[i] = Query(l[i], r[i]);
+  void InitInternal() {
+    for (int64_t i = capacity_ - 1; i > 0; --i) {
+      values_[i] = op_(values_[i << 1], values_[(i << 1) | 1]);
     }
   }
 
   const Operator op_{};
-  const int64_t size_;
+  int64_t size_;
   int64_t capacity_;
   const T identity_element_;
   std::vector<T> values_;
@@ -284,11 +146,16 @@ class SegmentTree {
 template <typename T>
 class SumSegmentTree final : public SegmentTree<T, std::plus<T>> {
  public:
-  SumSegmentTree(int64_t size) : SegmentTree<T, std::plus<T>>(size, T(0)) {}
+  explicit SumSegmentTree(int64_t size)
+      : SegmentTree<T, std::plus<T>>(size, T(0)) {}
+
+  template <class InputIterator>
+  SumSegmentTree(InputIterator first, InputIterator last)
+      : SegmentTree<T, std::plus<T>>(first, last, T(0)) {}
 
   // Get the 1st index where the scan (prefix sum) is not less than value.
   // Time complexity: O(logN)
-  int64_t ScanLowerBound(const T& value) const {
+  int64_t ScanLowerBound(T value) const {
     if (value > this->values_[1]) {
       return this->size_;
     }
@@ -296,7 +163,7 @@ class SumSegmentTree final : public SegmentTree<T, std::plus<T>> {
     T current_value = value;
     while (index < this->capacity_) {
       index <<= 1;
-      const T& lvalue = this->values_[index];
+      const T lvalue = this->values_[index];
       if (current_value > lvalue) {
         current_value -= lvalue;
         index |= 1;
@@ -304,207 +171,6 @@ class SumSegmentTree final : public SegmentTree<T, std::plus<T>> {
     }
     return index ^ this->capacity_;
   }
-
-  py::array_t<int64_t> ScanLowerBound(const py::array_t<T>& value) const {
-    py::array_t<int64_t> index = utils::NumpyEmptyLike<T, int64_t>(value);
-    BatchScanLowerBoundImpl(value.size(), value.data(), index.mutable_data());
-    return index;
-  }
-
-  torch::Tensor ScanLowerBound(const torch::Tensor& value) const {
-    assert(value.dtype() == utils::TorchDataType<T>::value);
-    const torch::Tensor value_contiguous = value.contiguous();
-    torch::Tensor index = torch::empty_like(value_contiguous, torch::kInt64);
-    const int64_t n = value_contiguous.numel();
-    BatchScanLowerBoundImpl(n, value_contiguous.data_ptr<T>(),
-                            index.data_ptr<int64_t>());
-    return index;
-  }
-
- protected:
-  void BatchScanLowerBoundImpl(int64_t n, const T* value,
-                               int64_t* index) const {
-    for (int64_t i = 0; i < n; ++i) {
-      index[i] = ScanLowerBound(value[i]);
-    }
-  }
 };
-
-template <typename T>
-struct MinOp {
-  T operator()(const T& lhs, const T& rhs) const { return std::min(lhs, rhs); }
-};
-
-template <typename T>
-class MinSegmentTree final : public SegmentTree<T, MinOp<T>> {
- public:
-  MinSegmentTree(int64_t size)
-      : SegmentTree<T, MinOp<T>>(size, std::numeric_limits<T>::max()) {}
-};
-
-template <typename T>
-void DefineSumSegmentTree(const std::string& type, py::module& m) {
-  const std::string pyclass = "SumSegmentTree" + type;
-  py::class_<SumSegmentTree<T>, std::shared_ptr<SumSegmentTree<T>>>(
-      m, pyclass.c_str())
-      .def(py::init<int64_t>())
-      .def_property_readonly("size", &SumSegmentTree<T>::size)
-      .def_property_readonly("capacity", &SumSegmentTree<T>::capacity)
-      .def_property_readonly("identity_element",
-                             &SumSegmentTree<T>::identity_element)
-      .def("__len__", &SumSegmentTree<T>::size)
-      .def("__getitem__",
-           py::overload_cast<int64_t>(&SumSegmentTree<T>::At, py::const_))
-      .def("__getitem__", py::overload_cast<const py::array_t<int64_t>&>(
-                              &SumSegmentTree<T>::At, py::const_))
-      .def("__getitem__", py::overload_cast<const torch::Tensor&>(
-                              &SumSegmentTree<T>::At, py::const_))
-      .def("at", py::overload_cast<int64_t>(&SumSegmentTree<T>::At, py::const_))
-      .def("at", py::overload_cast<const py::array_t<int64_t>&>(
-                     &SumSegmentTree<T>::At, py::const_))
-      .def("at", py::overload_cast<const torch::Tensor&>(&SumSegmentTree<T>::At,
-                                                         py::const_))
-      .def("__setitem__",
-           py::overload_cast<int64_t, const T&>(&SumSegmentTree<T>::Update))
-      .def("__setitem__",
-           py::overload_cast<const py::array_t<int64_t>&, const T&>(
-               &SumSegmentTree<T>::Update))
-      .def(
-          "__setitem__",
-          py::overload_cast<const py::array_t<int64_t>&, const py::array_t<T>&>(
-              &SumSegmentTree<T>::Update))
-      .def("__setitem__", py::overload_cast<const torch::Tensor&, const T&>(
-                              &SumSegmentTree<T>::Update))
-      .def("__setitem__",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
-               &SumSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<int64_t, const T&>(&SumSegmentTree<T>::Update))
-      .def("update", py::overload_cast<const py::array_t<int64_t>&, const T&>(
-                         &SumSegmentTree<T>::Update))
-      .def(
-          "update",
-          py::overload_cast<const py::array_t<int64_t>&, const py::array_t<T>&>(
-              &SumSegmentTree<T>::Update))
-      .def("update", py::overload_cast<const py::array_t<int64_t>&, const T&,
-                                       const py::array_t<bool>&>(
-                         &SumSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const py::array_t<int64_t>&, const py::array_t<T>&,
-                             const py::array_t<bool>&>(
-               &SumSegmentTree<T>::Update))
-      .def("update", py::overload_cast<const torch::Tensor&, const T&>(
-                         &SumSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
-               &SumSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const torch::Tensor&, const T&,
-                             const torch::Tensor&>(&SumSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&,
-                             const torch::Tensor&>(&SumSegmentTree<T>::Update))
-      .def("query", py::overload_cast<int64_t, int64_t>(
-                        &SumSegmentTree<T>::Query, py::const_))
-      .def("query", py::overload_cast<const py::array_t<int64_t>&,
-                                      const py::array_t<int64_t>&>(
-                        &SumSegmentTree<T>::Query, py::const_))
-      .def("query",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
-               &SumSegmentTree<T>::Query, py::const_))
-      .def("scan_lower_bound",
-           py::overload_cast<const T&>(&SumSegmentTree<T>::ScanLowerBound,
-                                       py::const_))
-      .def("scan_lower_bound",
-           py::overload_cast<const py::array_t<T>&>(
-               &SumSegmentTree<T>::ScanLowerBound, py::const_))
-      .def("scan_lower_bound",
-           py::overload_cast<const torch::Tensor&>(
-               &SumSegmentTree<T>::ScanLowerBound, py::const_))
-      .def(py::pickle([](const SumSegmentTree<T>& s) { return s.DumpValues(); },
-                      [](const py::array_t<T>& arr) {
-                        SumSegmentTree<T> s(arr.size());
-                        s.LoadValues(arr);
-                        return s;
-                      }));
-}
-
-template <typename T>
-void DefineMinSegmentTree(const std::string& type, py::module& m) {
-  const std::string pyclass = "MinSegmentTree" + type;
-  py::class_<MinSegmentTree<T>, std::shared_ptr<MinSegmentTree<T>>>(
-      m, pyclass.c_str())
-      .def(py::init<int64_t>())
-      .def_property_readonly("size", &MinSegmentTree<T>::size)
-      .def_property_readonly("capacity", &MinSegmentTree<T>::capacity)
-      .def_property_readonly("identity_element",
-                             &MinSegmentTree<T>::identity_element)
-      .def("__len__", &MinSegmentTree<T>::size)
-      .def("__getitem__",
-           py::overload_cast<int64_t>(&MinSegmentTree<T>::At, py::const_))
-      .def("__getitem__", py::overload_cast<const py::array_t<int64_t>&>(
-                              &MinSegmentTree<T>::At, py::const_))
-      .def("__getitem__", py::overload_cast<const torch::Tensor&>(
-                              &MinSegmentTree<T>::At, py::const_))
-      .def("at", py::overload_cast<int64_t>(&MinSegmentTree<T>::At, py::const_))
-      .def("at", py::overload_cast<const py::array_t<int64_t>&>(
-                     &MinSegmentTree<T>::At, py::const_))
-      .def("at", py::overload_cast<const torch::Tensor&>(&MinSegmentTree<T>::At,
-                                                         py::const_))
-      .def("__setitem__",
-           py::overload_cast<int64_t, const T&>(&MinSegmentTree<T>::Update))
-      .def("__setitem__",
-           py::overload_cast<const py::array_t<int64_t>&, const T&>(
-               &MinSegmentTree<T>::Update))
-      .def(
-          "__setitem__",
-          py::overload_cast<const py::array_t<int64_t>&, const py::array_t<T>&>(
-              &MinSegmentTree<T>::Update))
-      .def("__setitem__", py::overload_cast<const torch::Tensor&, const T&>(
-                              &MinSegmentTree<T>::Update))
-      .def("__setitem__",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
-               &MinSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<int64_t, const T&>(&MinSegmentTree<T>::Update))
-      .def("update", py::overload_cast<const py::array_t<int64_t>&, const T&>(
-                         &MinSegmentTree<T>::Update))
-      .def(
-          "update",
-          py::overload_cast<const py::array_t<int64_t>&, const py::array_t<T>&>(
-              &MinSegmentTree<T>::Update))
-      .def("update", py::overload_cast<const py::array_t<int64_t>&, const T&,
-                                       const py::array_t<bool>&>(
-                         &MinSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const py::array_t<int64_t>&, const py::array_t<T>&,
-                             const py::array_t<bool>&>(
-               &MinSegmentTree<T>::Update))
-      .def("update", py::overload_cast<const torch::Tensor&, const T&>(
-                         &MinSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
-               &MinSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const torch::Tensor&, const T&,
-                             const torch::Tensor&>(&MinSegmentTree<T>::Update))
-      .def("update",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&,
-                             const torch::Tensor&>(&MinSegmentTree<T>::Update))
-      .def("query", py::overload_cast<int64_t, int64_t>(
-                        &MinSegmentTree<T>::Query, py::const_))
-      .def("query", py::overload_cast<const py::array_t<int64_t>&,
-                                      const py::array_t<int64_t>&>(
-                        &MinSegmentTree<T>::Query, py::const_))
-      .def("query",
-           py::overload_cast<const torch::Tensor&, const torch::Tensor&>(
-               &MinSegmentTree<T>::Query, py::const_))
-      .def(py::pickle([](const MinSegmentTree<T>& s) { return s.DumpValues(); },
-                      [](const py::array_t<T>& arr) {
-                        MinSegmentTree<T> s(arr.size());
-                        s.LoadValues(arr);
-                        return s;
-                      }));
-}
 
 }  // namespace rlmeta

--- a/rlmeta/cc/segment_tree_pybind.h
+++ b/rlmeta/cc/segment_tree_pybind.h
@@ -1,0 +1,326 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <torch/extension.h>
+#include <torch/torch.h>
+
+#include "rlmeta/cc/numpy_utils.h"
+#include "rlmeta/cc/segment_tree.h"
+#include "rlmeta/cc/torch_utils.h"
+
+namespace py = pybind11;
+
+namespace rlmeta {
+
+namespace {
+
+template <typename T>
+void SumSegmentTreeAt(const SumSegmentTree<T>& sum_tree, int64_t n,
+                      const int64_t* index, T* value) {
+  for (int64_t i = 0; i < n; ++i) {
+    value[i] = sum_tree.At(index[i]);
+  }
+}
+
+template <typename T>
+py::array_t<T> SumSegmentTreeAt(const SumSegmentTree<T>& sum_tree,
+                                const py::array_t<int64_t>& index) {
+  py::array_t<T> value = utils::NumpyEmptyLike<int64_t, T>(index);
+  SumSegmentTreeAt<T>(sum_tree, index.size(), index.data(),
+                      value.mutable_data());
+  return value;
+}
+
+template <typename T>
+torch::Tensor SumSegmentTreeAt(const SumSegmentTree<T>& sum_tree,
+                               const torch::Tensor& index) {
+  assert(index.dtype() == torch::kInt64);
+  const torch::Tensor index_contiguous = index.contiguous();
+  torch::Tensor value =
+      torch::empty_like(index_contiguous, utils::TorchDataType<T>::value);
+  SumSegmentTreeAt<T>(sum_tree, index_contiguous.numel(),
+                      index_contiguous.data_ptr<int64_t>(),
+                      value.data_ptr<T>());
+  return value;
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(int64_t n, const int64_t* index, T value,
+                          SumSegmentTree<T>& sum_tree) {
+  for (int64_t i = 0; i < n; ++i) {
+    sum_tree.Update(index[i], value);
+  }
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(int64_t n, const int64_t* index, const T* value,
+                          SumSegmentTree<T>& sum_tree) {
+  for (int64_t i = 0; i < n; ++i) {
+    sum_tree.Update(index[i], value[i]);
+  }
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(int64_t n, const int64_t* index, const T* value,
+                          const bool* mask, SumSegmentTree<T>& sum_tree) {
+  for (int64_t i = 0; i < n; ++i) {
+    if (mask[i]) {
+      sum_tree.Update(index[i], value[i]);
+    }
+  }
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(const py::array_t<int64_t>& index, T value,
+                          SumSegmentTree<T>& sum_tree) {
+  SumSegmentTreeUpdate<T>(index.size(), index.data(), value, sum_tree);
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(const py::array_t<int64_t>& index,
+                          const py::array_t<T>& value,
+                          SumSegmentTree<T>& sum_tree) {
+  assert(index.size() == value.size());
+  SumSegmentTreeUpdate<T>(index.size(), index.data(), value.data(), sum_tree);
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(const py::array_t<int64_t>& index,
+                          const py::array_t<T>& value,
+                          const py::array_t<bool>& mask,
+                          SumSegmentTree<T>& sum_tree) {
+  assert(index.size() == value.size());
+  assert(index.size() == mask.size());
+  SumSegmentTreeUpdate<T>(index.size(), index.data(), value.data(), mask.data(),
+                          sum_tree);
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(const torch::Tensor& index, T value,
+                          SumSegmentTree<T>& sum_tree) {
+  assert(index.dtype() == torch::kInt64);
+  const torch::Tensor index_contiguous = index.contiguous();
+  SumSegmentTreeUpdate<T>(index_contiguous.numel(),
+                          index_contiguous.data_ptr<int64_t>(), value,
+                          sum_tree);
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(const torch::Tensor& index,
+                          const torch::Tensor& value,
+                          SumSegmentTree<T>& sum_tree) {
+  assert(index.dtype() == torch::kInt64);
+  assert(value.dtype() == utils::TorchDataType<T>::value);
+  const torch::Tensor index_contiguous = index.contiguous();
+  const torch::Tensor value_contiguous = value.contiguous();
+  SumSegmentTreeUpdate<T>(index_contiguous.numel(),
+                          index_contiguous.data_ptr<int64_t>(),
+                          value_contiguous.data_ptr<T>(), sum_tree);
+}
+
+template <typename T>
+void SumSegmentTreeUpdate(const torch::Tensor& index,
+                          const torch::Tensor& value, const torch::Tensor& mask,
+                          SumSegmentTree<T>& sum_tree) {
+  assert(index.dtype() == torch::kInt64);
+  assert(value.dtype() == utils::TorchDataType<T>::value);
+  assert(mask.dtype() == torch::kBool);
+  const torch::Tensor index_contiguous = index.contiguous();
+  const torch::Tensor value_contiguous = value.contiguous();
+  const torch::Tensor mask_contiguous = mask.contiguous();
+  SumSegmentTreeUpdate<T>(index_contiguous.numel(),
+                          index_contiguous.data_ptr<int64_t>(),
+                          value_contiguous.data_ptr<T>(),
+                          mask_contiguous.data_ptr<bool>(), sum_tree);
+}
+
+template <typename T>
+void SumSegmentTreeQuery(const SumSegmentTree<T>& sum_tree, int64_t n,
+                         const int64_t* l, const int64_t* r, T* result) {
+  for (int64_t i = 0; i < n; ++i) {
+    result[i] = sum_tree.Query(l[i], r[i]);
+  }
+}
+
+template <typename T>
+py::array_t<T> SumSegmentTreeQuery(const SumSegmentTree<T>& sum_tree,
+                                   const py::array_t<int64_t>& l,
+                                   const py::array_t<int64_t>& r) {
+  assert(l.size() == r.size());
+  py::array_t<T> ret = utils::NumpyEmptyLike<int64_t, T>(l);
+  SumSegmentTreeQuery<T>(sum_tree, l.size(), l.data(), r.data(),
+                         ret.mutable_data());
+  return ret;
+}
+
+template <typename T>
+torch::Tensor SumSegmentTreeQuery(const SumSegmentTree<T>& sum_tree,
+                                  const torch::Tensor& l,
+                                  const torch::Tensor& r) {
+  assert(l.dtype() == torch::kInt64);
+  assert(r.dtype() == torch::kInt64);
+  assert(l.sizes() == r.sizes());
+  const torch::Tensor l_contiguous = l.contiguous();
+  const torch::Tensor r_contiguous = r.contiguous();
+  torch::Tensor ret =
+      torch::empty_like(l_contiguous, utils::TorchDataType<T>::value);
+  SumSegmentTreeQuery<T>(sum_tree, l_contiguous.numel(),
+                         l_contiguous.data_ptr<int64_t>(),
+                         r_contiguous.data_ptr<int64_t>(), ret.data_ptr<T>());
+  return ret;
+}
+
+template <typename T>
+void SumSegmentTreeScanLowerBound(const SumSegmentTree<T>& sum_tree, int64_t n,
+                                  const T* value, int64_t* index) {
+  for (int64_t i = 0; i < n; ++i) {
+    index[i] = sum_tree.ScanLowerBound(value[i]);
+  }
+}
+
+template <typename T>
+py::array_t<int64_t> SumSegmentTreeScanLowerBound(
+    const SumSegmentTree<T>& sum_tree, const py::array_t<T>& value) {
+  py::array_t<int64_t> index = utils::NumpyEmptyLike<T, int64_t>(value);
+  SumSegmentTreeScanLowerBound<T>(sum_tree, value.size(), value.data(),
+                                  index.mutable_data());
+  return index;
+}
+
+template <typename T>
+torch::Tensor SumSegmentTreeScanLowerBound(const SumSegmentTree<T>& sum_tree,
+                                           const torch::Tensor& value) {
+  assert(value.dtype() == utils::TorchDataType<T>::value);
+  const torch::Tensor value_contiguous = value.contiguous();
+  torch::Tensor index = torch::empty_like(value_contiguous, torch::kInt64);
+  SumSegmentTreeScanLowerBound<T>(sum_tree, value_contiguous.numel(),
+                                  value_contiguous.data_ptr<T>(),
+                                  index.data_ptr<int64_t>());
+  return index;
+}
+
+}  // namespace
+
+template <typename T>
+void DefineSumSegmentTree(const std::string& type, py::module& m) {
+  const std::string pyclass = "SumSegmentTree" + type;
+  py::class_<SumSegmentTree<T>, std::shared_ptr<SumSegmentTree<T>>>(
+      m, pyclass.c_str())
+      .def(py::init<int64_t>())
+      .def_property_readonly("size", &SumSegmentTree<T>::size)
+      .def_property_readonly("capacity", &SumSegmentTree<T>::capacity)
+      .def_property_readonly("identity_element",
+                             &SumSegmentTree<T>::identity_element)
+      .def("__len__", &SumSegmentTree<T>::size)
+      .def("__getitem__", &SumSegmentTree<T>::At)
+      .def("__getitem__",
+           [](const SumSegmentTree<T>& sum_tree, const py::array_t<T>& index) {
+             return SumSegmentTreeAt<T>(sum_tree, index);
+           })
+      .def("__getitem__",
+           [](const SumSegmentTree<T>& sum_tree, const torch::Tensor& index) {
+             return SumSegmentTreeAt<T>(sum_tree, index);
+           })
+      .def("__setitem__", &SumSegmentTree<T>::Update)
+      .def("__setitem__",
+           [](SumSegmentTree<T>& sum_tree, const py::array_t<int64_t>& index,
+              T value) {
+             return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+           })
+      .def("__setitem__",
+           [](SumSegmentTree<T>& sum_tree, const py::array_t<int64_t>& index,
+              const py::array_t<T>& value) {
+             return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+           })
+      .def(
+          "__setitem__",
+          [](SumSegmentTree<T>& sum_tree, const torch::Tensor& index, T value) {
+            return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+          })
+      .def("__setitem__",
+           [](SumSegmentTree<T>& sum_tree, const torch::Tensor& index,
+              const torch::Tensor& value) {
+             return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+           })
+      .def("at", &SumSegmentTree<T>::At)
+      .def("at",
+           [](const SumSegmentTree<T>& sum_tree, const py::array_t<T>& index) {
+             return SumSegmentTreeAt<T>(sum_tree, index);
+           })
+      .def("at",
+           [](const SumSegmentTree<T>& sum_tree, const torch::Tensor& index) {
+             return SumSegmentTreeAt<T>(sum_tree, index);
+           })
+      .def("update", &SumSegmentTree<T>::Update)
+      .def("update",
+           [](SumSegmentTree<T>& sum_tree, const py::array_t<int64_t>& index,
+              T value) {
+             return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+           })
+      .def("update",
+           [](SumSegmentTree<T>& sum_tree, const py::array_t<int64_t>& index,
+              const py::array_t<T>& value) {
+             return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+           })
+      .def("update",
+           [](SumSegmentTree<T>& sum_tree, const py::array_t<int64_t>& index,
+              const py::array_t<T>& value, const py::array_t<bool>& mask) {
+             return SumSegmentTreeUpdate<T>(index, value, mask, sum_tree);
+           })
+      .def(
+          "update",
+          [](SumSegmentTree<T>& sum_tree, const torch::Tensor& index, T value) {
+            return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+          })
+      .def("update",
+           [](SumSegmentTree<T>& sum_tree, const torch::Tensor& index,
+              const torch::Tensor& value) {
+             return SumSegmentTreeUpdate<T>(index, value, sum_tree);
+           })
+      .def("update",
+           [](SumSegmentTree<T>& sum_tree, const torch::Tensor& index,
+              const torch::Tensor& value, const torch::Tensor& mask) {
+             return SumSegmentTreeUpdate<T>(index, value, mask, sum_tree);
+           })
+      .def("query", &SumSegmentTree<T>::Query)
+      .def("query",
+           [](const SumSegmentTree<T>& sum_tree, const py::array_t<int64_t>& l,
+              const py::array_t<int64_t>& r) {
+             return SumSegmentTreeQuery<T>(sum_tree, l, r);
+           })
+      .def("query",
+           [](const SumSegmentTree<T>& sum_tree, const torch::Tensor& l,
+              const torch::Tensor& r) {
+             return SumSegmentTreeQuery<T>(sum_tree, l, r);
+           })
+      .def("scan_lower_bound", &SumSegmentTree<T>::ScanLowerBound)
+      .def("scan_lower_bound",
+           [](const SumSegmentTree<T>& sum_tree, const py::array_t<T>& value) {
+             return SumSegmentTreeScanLowerBound<T>(sum_tree, value);
+           })
+      .def("scan_lower_bound",
+           [](const SumSegmentTree<T>& sum_tree, const torch::Tensor& value) {
+             return SumSegmentTreeScanLowerBound<T>(sum_tree, value);
+           })
+      .def(py::pickle(
+          [](const SumSegmentTree<T>& sum_tree) {
+            const int64_t n = sum_tree.size();
+            py::array_t<T> ret(n);
+            T* ret_data = ret.mutable_data();
+            for (int64_t i = 0; i < n; ++i) {
+              ret_data[i] = sum_tree.At(i);
+            }
+            return ret;
+          },
+          [](const py::array_t<T>& arr) {
+            return SumSegmentTree<T>(arr.data(), arr.data() + arr.size());
+          }));
+}
+
+}  // namespace rlmeta

--- a/rlmeta/data/__init__.py
+++ b/rlmeta/data/__init__.py
@@ -5,10 +5,9 @@
 
 from _rlmeta_extension import CircularBuffer
 from _rlmeta_extension import TimestampManager
-from rlmeta.data.segment_tree import SumSegmentTree, MinSegmentTree
+from rlmeta.data.segment_tree import SumSegmentTree
 
 __all__ = [
     "CircularBuffer",
     "SumSegmentTree",
-    "MinSegmentTree",
 ]

--- a/rlmeta/data/segment_tree.py
+++ b/rlmeta/data/segment_tree.py
@@ -8,23 +8,24 @@ from typing import Optional, Union
 import numpy as np
 import torch
 
-from _rlmeta_extension import (SumSegmentTreeFp32, SumSegmentTreeFp64,
-                               MinSegmentTreeFp32, MinSegmentTreeFp64)
+from _rlmeta_extension import SumSegmentTreeFp32, SumSegmentTreeFp64
 from rlmeta.core.types import Tensor
 
-SegmentTreeImpl = Union[SumSegmentTreeFp32, SumSegmentTreeFp64,
-                        MinSegmentTreeFp32, MinSegmentTreeFp64]
+SumSegmentTreeImpl = Union[SumSegmentTreeFp32, SumSegmentTreeFp64]
 Index = Union[int, np.ndarray, torch.Tensor]
 Value = Union[float, np.ndarray, torch.Tensor]
 
 
-class SegmentTree:
+class SumSegmentTree:
 
-    def __init__(self,
-                 impl: SegmentTreeImpl,
-                 dtype: np.dtype = np.float64) -> None:
-        self._impl = impl
+    def __init__(self, size: int, dtype: np.dtype = np.float64) -> None:
         self._dtype = dtype
+        if dtype == np.float32:
+            self._impl = SumSegmentTreeFp32(size)
+        elif dtype == np.float64:
+            self._impl = SumSegmentTreeFp64(size)
+        else:
+            assert False, "Unsupported data type " + str(dtype)
 
     @property
     def dtype(self) -> np.dtype:
@@ -62,29 +63,5 @@ class SegmentTree:
     def query(self, l: Index, r: Index) -> Value:
         return self._impl.query(l, r)
 
-
-class SumSegmentTree(SegmentTree):
-
-    def __init__(self, size: int, dtype: np.dtype = np.float64) -> None:
-        if dtype == np.float32:
-            impl = SumSegmentTreeFp32(size)
-        elif dtype == np.float64:
-            impl = SumSegmentTreeFp64(size)
-        else:
-            assert False, "Unsupported data type " + str(dtype)
-        super().__init__(impl, dtype)
-
     def scan_lower_bound(self, value: Value) -> Index:
         return self._impl.scan_lower_bound(value)
-
-
-class MinSegmentTree(SegmentTree):
-
-    def __init__(self, size: int, dtype: np.dtype = np.float64) -> None:
-        if dtype == np.float32:
-            impl = MinSegmentTreeFp32(size)
-        elif dtype == np.float64:
-            impl = MinSegmentTreeFp64(size)
-        else:
-            assert False, "Unsupported data type " + str(dtype)
-        super().__init__(impl, dtype)

--- a/tests/core/replay_buffer_test.py
+++ b/tests/core/replay_buffer_test.py
@@ -162,15 +162,14 @@ class PrioritizedReplayBufferTest(TestCaseBase):
         index = torch.arange(self.size)
         weight = torch.rand(self.size)
         expected_weight = torch.pow(weight, self.alpha)
-        expected_weight = torch.pow(
-            (expected_weight * self.size) / (expected_weight.min() * self.size),
-            -self.beta)
 
         replay_buffer.update_priority(index, weight)
-        _, cur_weight, cur_index, cur_timestamp = replay_buffer.sample(
-            self.batch_size)
-        self.assert_tensor_close(cur_weight, expected_weight[cur_index],
-                                 self.rtol, self.atol)
+        _, cur_weight, cur_index, _ = replay_buffer.sample(self.batch_size)
+        expected_weight = expected_weight[cur_index]
+        expected_weight = (expected_weight /
+                           expected_weight.min()).pow(-self.beta)
+        self.assert_tensor_close(cur_weight, expected_weight, self.rtol,
+                                 self.atol)
 
 
 if __name__ == "__main__":

--- a/tests/data/segment_tree_test.py
+++ b/tests/data/segment_tree_test.py
@@ -11,7 +11,7 @@ from math import prod
 import numpy as np
 import torch
 
-from rlmeta.data import SumSegmentTree, MinSegmentTree
+from rlmeta.data import SumSegmentTree
 from tests.test_utils import TestCaseBase
 
 
@@ -70,13 +70,6 @@ class SumSegmentTreeTest(TestCaseBase):
         index = index.view(self.query_size)
         origin_value = self.segment_tree[index]
         mask = torch.randint(2, size=self.query_size, dtype=torch.bool)
-
-        value = np.random.randn()
-        self.segment_tree.update(index, value, mask)
-        self.assert_tensor_equal(
-            self.segment_tree[index],
-            torch.where(mask, torch.full(self.query_size, value), origin_value))
-        self.segment_tree[index] = origin_value
 
         value = torch.randn(self.query_size)
         self.segment_tree.update(index, value, mask)


### PR DESCRIPTION
This PR made the following changes.
1. Separate C++ and Python APIs for SegmentTree so that it can be used in future C++ modules.
2. Add Resize and ShrinkToFit Apis for SegmentTree
3. Remove MinSegmentTree and use batch min instead of global min in PrioritizedReplayBuffer.