### PR TITLE
Switch to latest version of moolib

### DIFF
--- a/examples/atari/dqn/atari_apex_dqn.py
+++ b/examples/atari/dqn/atari_apex_dqn.py
@@ -33,7 +33,8 @@ def main(cfg):
     logging.info(hydra_utils.config_to_json(cfg))
 
     env = atari_wrappers.make_atari(cfg.env)
-    train_model = AtariDQNModel(env.action_space.n).to(cfg.train_device)
+    train_model = AtariDQNModel(env.action_space.n,
+                                reward_rescaling=False).to(cfg.train_device)
     optimizer = torch.optim.Adam(train_model.parameters(), lr=cfg.lr)
 
     infer_model = copy.deepcopy(train_model).to(cfg.infer_device)

--- a/rlmeta/core/remote.py
+++ b/rlmeta/core/remote.py
@@ -117,7 +117,6 @@ class Remote:
         if self._connected:
             return
         self._client = moolib.Rpc()
-        self._client.set_transports(["uv"])
         self._client.set_name(self._name)
         self._client.set_timeout(self._timeout)
         self._client.connect(self._server_addr)

--- a/rlmeta/core/server.py
+++ b/rlmeta/core/server.py
@@ -86,7 +86,6 @@ class Server(Launchable):
                 service.init_execution()
 
         self._server = moolib.Rpc()
-        self._server.set_transports(["uv"])
         self._server.set_name(self._name)
         self._server.set_timeout(self._timeout)
         console.log(f"Server={self.name} listening to {self._addr}")


### PR DESCRIPTION
After https://github.com/facebookresearch/moolib/pull/38, moolib has a new backend which is not using TensorPipe and fixed the performance issue. So here we make this change to switch to the latest version of moolib.
This change also slightly modify the implementation of ApeX-DQN to improve the performance.