### PR TITLE
Fix bug in TensorCircularBuffer::Clear()

### DIFF
--- a/rlmeta/cc/storage/circular_buffer.cc
+++ b/rlmeta/cc/storage/circular_buffer.cc
@@ -105,6 +105,7 @@ void DefineCircularBuffer(py::module& m) {
                      &CircularBuffer::At, py::const_))
       .def("at", py::overload_cast<const torch::Tensor&>(&CircularBuffer::At,
                                                          py::const_))
+      .def("reset", &CircularBuffer::Reset)
       .def("clear", &CircularBuffer::Clear)
       .def("append", &CircularBuffer::Append)
       .def("extend",

--- a/rlmeta/cc/storage/circular_buffer_base.h
+++ b/rlmeta/cc/storage/circular_buffer_base.h
@@ -25,6 +25,8 @@ class CircularBufferBase {
 
   virtual int64_t Size() const = 0;
 
+  virtual void Reset() { Clear(); }
+
   virtual void Clear() { cursor_ = 0; }
 
   virtual py::object At(int64_t key) const = 0;

--- a/rlmeta/cc/storage/schema.cc
+++ b/rlmeta/cc/storage/schema.cc
@@ -10,6 +10,28 @@
 
 namespace rlmeta {
 
+void Schema::Reset() {
+  if (meta_.has_value()) {
+    meta_.reset();
+    return;
+  }
+  if (vec_.has_value()) {
+    for (auto& sub : *vec_) {
+      sub.Reset();
+    }
+    vec_->clear();
+    vec_.reset();
+    return;
+  }
+  if (map_.has_value()) {
+    for (auto& [key, sub] : *map_) {
+      sub.Reset();
+    }
+    map_->clear();
+    map_.reset();
+  }
+}
+
 bool Schema::FromPythonImpl(const py::object& obj, bool packed_input,
                             int64_t& index) {
   if (utils::IsTorchTensor(obj)) {

--- a/rlmeta/cc/storage/schema.h
+++ b/rlmeta/cc/storage/schema.h
@@ -29,6 +29,8 @@ class Schema {
 
   int64_t size() const { return size_; }
 
+  void Reset();
+
   const std::optional<MetaData>& meta() const { return meta_; }
 
   const std::optional<std::vector<Schema>>& vec() const { return vec_; }

--- a/rlmeta/cc/storage/tensor_circular_buffer.cc
+++ b/rlmeta/cc/storage/tensor_circular_buffer.cc
@@ -186,7 +186,7 @@ std::pair<int64_t, std::optional<int64_t>> TensorCircularBuffer::Append(
 void TensorCircularBuffer::LoadData(const py::object& data,
                                     const py::array_t<int64_t>& keys,
                                     int64_t cursor, int64_t next_key) {
-  Clear();
+  Reset();
   schema_.FromPython(data, /*packed_input=*/true);
   initialized_ = true;
   data_.resize(schema_.size());
@@ -342,6 +342,7 @@ void DefineTensorCircularBuffer(py::module& m) {
                      &TensorCircularBuffer::At, py::const_))
       .def("at", py::overload_cast<const torch::Tensor&>(
                      &TensorCircularBuffer::At, py::const_))
+      .def("reset", &TensorCircularBuffer::Reset)
       .def("clear", &TensorCircularBuffer::Clear)
       .def("append", &TensorCircularBuffer::Append)
       .def("extend",

--- a/rlmeta/cc/storage/tensor_circular_buffer.h
+++ b/rlmeta/cc/storage/tensor_circular_buffer.h
@@ -44,9 +44,15 @@ class TensorCircularBuffer : public CircularBufferBase {
 
   int64_t next_key() const { return next_key_; }
 
+  void Reset() override {
+    Clear();
+    schema_.Reset();
+    data_.clear();
+    initialized_ = false;
+  }
+
   void Clear() override {
     CircularBufferBase::Clear();
-    data_.clear();
     keys_.clear();
     keys_.reserve(capacity_);
     key_to_index_.clear();

--- a/rlmeta/core/replay_buffer.py
+++ b/rlmeta/core/replay_buffer.py
@@ -79,6 +79,11 @@ class ReplayBuffer(remote.Remotable, Launchable):
         return self.size, self.capacity
 
     @remote.remote_method(batch_size=None)
+    def reset(self) -> None:
+        self._storage.reset()
+        self._sampler.reset()
+
+    @remote.remote_method(batch_size=None)
     def clear(self) -> None:
         self._storage.clear()
         self._sampler.reset()

--- a/rlmeta/data/__init__.py
+++ b/rlmeta/data/__init__.py
@@ -3,10 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from _rlmeta_extension import CircularBuffer
 from rlmeta.data.segment_tree import SumSegmentTree
 
 __all__ = [
-    "CircularBuffer",
     "SumSegmentTree",
 ]

--- a/rlmeta/storage/circular_buffer.py
+++ b/rlmeta/storage/circular_buffer.py
@@ -42,6 +42,9 @@ class CircularBuffer(Storage):
     def size(self) -> int:
         return self._impl.size
 
+    def reset(self) -> None:
+        self._impl.reset()
+
     def clear(self) -> None:
         self._impl.clear()
 

--- a/rlmeta/storage/storage.py
+++ b/rlmeta/storage/storage.py
@@ -38,6 +38,11 @@ class Storage(abc.ABC):
         """
 
     @abc.abstractmethod
+    def reset(self) -> None:
+        """
+        """
+
+    @abc.abstractmethod
     def clear(self) -> None:
         """
         """

--- a/rlmeta/storage/tensor_circular_buffer.py
+++ b/rlmeta/storage/tensor_circular_buffer.py
@@ -32,6 +32,9 @@ class TensorCircularBuffer(Storage):
     def size(self) -> int:
         return self._impl.size
 
+    def reset(self) -> None:
+        self._impl.reset()
+
     def clear(self) -> None:
         self._impl.clear()
 

--- a/tests/core/replay_buffer_test.py
+++ b/tests/core/replay_buffer_test.py
@@ -146,6 +146,8 @@ class PrioritizedReplayBufferTest(TestCaseBase):
         replay_buffer.reset()
         self.assertEqual(len(replay_buffer), 0)
         self.assertFalse(replay_buffer._storage._impl.initialized)
+        replay_buffer.extend(self.data)
+        self.assertEqual(len(replay_buffer), len(self.data))
 
     def test_clear(self) -> None:
         replay_buffer = ReplayBuffer(TensorCircularBuffer(self.size),

--- a/tests/core/rescalers_test.py
+++ b/tests/core/rescalers_test.py
@@ -16,8 +16,8 @@ class RescalerTest(TestCaseBase):
 
     def setUp(self) -> None:
         self.size = (4, 5)
-        self.rtol = 1e-6
-        self.atol = 1e-6
+        self.rtol = 1e-5
+        self.atol = 1e-5
 
     def test_rms_rescaler(self) -> None:
         rms_rescaler = RMSRescaler(self.size)


### PR DESCRIPTION
This PR fixed the crash issue for TensorCircularBuffer::Clear() and also add a Reset() function for CircularBuffers. The differences of Clear() and Reset() are listed below. The related issue is https://github.com/facebookresearch/rlmeta/issues/85
- Clear() will only make the TensorCircularBuffer's size == 0, but will not reset the internal status such as initialized_ and schema_. Clear() will be more efficient for adding the same data schema multiple times.
- Reset() will call Clear() and then reset all of the internal status such as initialized_ and schema_.