### PR TITLE
Add replacement argument to ReplayBuffer.sample

### DIFF
--- a/rlmeta/cc/samplers/prioritized_sampler.h
+++ b/rlmeta/cc/samplers/prioritized_sampler.h
@@ -213,8 +213,6 @@ class PrioritizedSampler : public Sampler {
     return mask;
   }
 
-  KeysAndPriorities Sample(int64_t num) const override;
-
   py::array_t<int64_t> DumpKeys() const {
     return utils::AsNumpyArray<int64_t>(keys_);
   }
@@ -235,6 +233,10 @@ class PrioritizedSampler : public Sampler {
   }
 
  protected:
+  KeysAndProbabilities SampleWithReplacement(int64_t num_samples) override;
+
+  KeysAndProbabilities SampleWithoutReplacement(int64_t num_samples) override;
+
   double ComputePriority(double priority) const {
     return std::pow(priority + eps_, priority_exponent_);
   }

--- a/rlmeta/cc/samplers/sampler.cc
+++ b/rlmeta/cc/samplers/sampler.cc
@@ -43,7 +43,8 @@ void DefineSampler(py::module& m) {
       .def("delete",
            py::overload_cast<const py::array_t<int64_t>&>(&Sampler::Delete))
       .def("delete", py::overload_cast<const torch::Tensor&>(&Sampler::Delete))
-      .def("sample", &Sampler::Sample);
+      .def("sample", &Sampler::Sample, py::arg("num_samples"),
+           py::arg("replacement") = false);
 }
 
 }  // namespace rlmeta

--- a/rlmeta/cc/samplers/uniform_sampler.h
+++ b/rlmeta/cc/samplers/uniform_sampler.h
@@ -49,6 +49,7 @@ class UniformSampler : public Sampler {
   int64_t Size() const override { return keys_.size(); }
 
   void Reset() override {
+    random_gen_.seed();
     keys_.clear();
     key_to_index_.clear();
   }
@@ -172,8 +173,6 @@ class UniformSampler : public Sampler {
     return mask;
   }
 
-  KeysAndPriorities Sample(int64_t num) const override;
-
   py::array_t<int64_t> DumpKeys() const {
     return utils::AsNumpyArray<int64_t>(keys_);
   }
@@ -181,6 +180,10 @@ class UniformSampler : public Sampler {
   void LoadKeys(const py::array_t<int64_t>& arr);
 
  protected:
+  KeysAndProbabilities SampleWithReplacement(int64_t num_samples) override;
+
+  KeysAndProbabilities SampleWithoutReplacement(int64_t num_samples) override;
+
   void InsertImpl(int64_t n, const int64_t* keys, double priority, bool* mask);
   void InsertImpl(int64_t n, const int64_t* keys, const double* priorities,
                   bool* mask);


### PR DESCRIPTION
This PR add a replacement argument in ReplayBuffer.sample with default False. Originally ReplayBuffer.sample was doing sample with replacement and now we default change it to sample without replacement. Given the size of ReplayBuffer is relatively large, the impact should be limited.