### PR TITLE
Add at/get/front/back APIs for CircularBuffer

### DIFF
--- a/rlmeta/cc/storage/tensor_circular_buffer.cc
+++ b/rlmeta/cc/storage/tensor_circular_buffer.cc
@@ -209,9 +209,6 @@ std::vector<int64_t> TensorCircularBuffer::AbsoluteIndices(
 }
 
 py::object TensorCircularBuffer::AtImpl(int64_t index) const {
-  if (index < 0) {
-    index += keys_.size();
-  }
   std::vector<torch::Tensor> ret;
   ret.reserve(data_.size());
   for (const torch::Tensor& tensor : data_) {

--- a/rlmeta/cc/storage/tensor_circular_buffer.cc
+++ b/rlmeta/cc/storage/tensor_circular_buffer.cc
@@ -153,20 +153,6 @@ void LoadNested(const Schema& schema, const py::object& src,
 
 }  // namespace
 
-py::object TensorCircularBuffer::At(int64_t key) const {
-  const auto it = key_to_index_.find(key);
-  if (it == key_to_index_.end()) {
-    return py::none();
-  }
-  const int64_t index = it->second;
-  std::vector<torch::Tensor> ret;
-  ret.reserve(data_.size());
-  for (const torch::Tensor& tensor : data_) {
-    ret.push_back(tensor[index].clone());
-  }
-  return RecoverNested(ret);
-}
-
 std::pair<int64_t, std::optional<int64_t>> TensorCircularBuffer::Append(
     const py::object& o) {
   if (!initialized_) {
@@ -213,8 +199,48 @@ py::object TensorCircularBuffer::RecoverNested(
   return RecoverNestedImpl(schema_, src);
 }
 
-py::object TensorCircularBuffer::BatchedAtImpl(int64_t n,
-                                               const int64_t* keys) const {
+std::vector<int64_t> TensorCircularBuffer::AbsoluteIndices(
+    int64_t n, const int64_t* indices) const {
+  std::vector<int64_t> ret(n);
+  for (int64_t i = 0; i < n; ++i) {
+    ret[i] = AbsoluteIndex(indices[i]);
+  }
+  return ret;
+}
+
+py::object TensorCircularBuffer::AtImpl(int64_t index) const {
+  if (index < 0) {
+    index += keys_.size();
+  }
+  std::vector<torch::Tensor> ret;
+  ret.reserve(data_.size());
+  for (const torch::Tensor& tensor : data_) {
+    ret.push_back(tensor[index].clone());
+  }
+  return RecoverNested(ret);
+}
+
+void TensorCircularBuffer::BatchedKeyAtImpl(int64_t n, const int64_t* indices,
+                                            int64_t* keys) const {
+  for (int64_t i = 0; i < n; ++i) {
+    keys[i] = keys_.at(indices[i]);
+  }
+}
+
+py::object TensorCircularBuffer::BatchedValueAtImpl(
+    int64_t n, const int64_t* indices) const {
+  const torch::Tensor indices_tensor =
+      torch::from_blob(const_cast<int64_t*>(indices), {n}, torch::kInt64);
+  std::vector<torch::Tensor> ret;
+  ret.reserve(data_.size());
+  for (const torch::Tensor& tensor : data_) {
+    ret.push_back(tensor.index({indices_tensor}));
+  }
+  return RecoverNested(ret);
+}
+
+py::object TensorCircularBuffer::BatchedGetImpl(int64_t n,
+                                                const int64_t* keys) const {
   std::vector<int64_t> indices;
   indices.reserve(n);
   for (int64_t i = 0; i < n; ++i) {
@@ -223,13 +249,7 @@ py::object TensorCircularBuffer::BatchedAtImpl(int64_t n,
       indices.push_back(it->second);
     }
   }
-  const torch::Tensor indices_tensor = torch::tensor(indices, torch::kInt64);
-  std::vector<torch::Tensor> ret;
-  ret.reserve(data_.size());
-  for (const torch::Tensor& tensor : data_) {
-    ret.push_back(tensor.index({indices_tensor}));
-  }
-  return RecoverNested(ret);
+  return BatchedValueAtImpl(indices.size(), indices.data());
 }
 
 std::pair<int64_t, std::optional<int64_t>> TensorCircularBuffer::Reserve() {
@@ -336,14 +356,22 @@ void DefineTensorCircularBuffer(py::module& m) {
                               &TensorCircularBuffer::At, py::const_))
       .def("__getitem__", py::overload_cast<const torch::Tensor&>(
                               &TensorCircularBuffer::At, py::const_))
+      .def("reset", &TensorCircularBuffer::Reset)
+      .def("clear", &TensorCircularBuffer::Clear)
+      .def("front", &TensorCircularBuffer::Front)
+      .def("back", &TensorCircularBuffer::Back)
       .def("at",
            py::overload_cast<int64_t>(&TensorCircularBuffer::At, py::const_))
       .def("at", py::overload_cast<const py::array_t<int64_t>&>(
                      &TensorCircularBuffer::At, py::const_))
       .def("at", py::overload_cast<const torch::Tensor&>(
                      &TensorCircularBuffer::At, py::const_))
-      .def("reset", &TensorCircularBuffer::Reset)
-      .def("clear", &TensorCircularBuffer::Clear)
+      .def("get",
+           py::overload_cast<int64_t>(&TensorCircularBuffer::Get, py::const_))
+      .def("get", py::overload_cast<const py::array_t<int64_t>&>(
+                      &TensorCircularBuffer::Get, py::const_))
+      .def("get", py::overload_cast<const torch::Tensor&>(
+                      &TensorCircularBuffer::Get, py::const_))
       .def("append", &TensorCircularBuffer::Append)
       .def("extend",
            py::overload_cast<const py::tuple&>(&TensorCircularBuffer::Extend))

--- a/rlmeta/core/replay_buffer.py
+++ b/rlmeta/core/replay_buffer.py
@@ -58,7 +58,8 @@ class ReplayBuffer(remote.Remotable, Launchable):
         return len(self._storage)
 
     def __getitem__(self, key: Union[int, Tensor]) -> NestedTensor:
-        return self._storage[key]
+        # return self._storage[key]
+        return self._storage.get(key)
 
     @property
     def capacity(self) -> int:
@@ -116,7 +117,8 @@ class ReplayBuffer(remote.Remotable, Launchable):
         replacement: bool = False
     ) -> Tuple[torch.Tensor, NestedTensor, torch.Tensor]:
         keys, probabilities = self._sampler.sample(num_samples, replacement)
-        values = self._storage[keys]
+        # values = self._storage[keys]
+        values = self._storage.get(keys)
         return torch.from_numpy(keys), values, torch.from_numpy(probabilities)
 
     @remote.remote_method(batch_size=None)

--- a/rlmeta/storage/tensor_circular_buffer.py
+++ b/rlmeta/storage/tensor_circular_buffer.py
@@ -12,17 +12,18 @@ import _rlmeta_extension
 from rlmeta.core.types import NestedTensor, Tensor
 from rlmeta.storage import Storage
 
+IndexType = Union[int, Tensor]
+KeyType = Union[int, Tensor]
+ValueType = NestedTensor
+
 
 class TensorCircularBuffer(Storage):
 
     def __init__(self, capacity: int) -> None:
         self._impl = _rlmeta_extension.TensorCircularBuffer(capacity)
 
-    def __getitem__(
-            self,
-            key: Union[int,
-                       Tensor]) -> Union[NestedTensor, Sequence[NestedTensor]]:
-        return self._impl[key]
+    def __getitem__(self, index: IndexType) -> Tuple[KeyType, ValueType]:
+        return self._impl[index]
 
     @property
     def capacity(self) -> int:
@@ -32,11 +33,26 @@ class TensorCircularBuffer(Storage):
     def size(self) -> int:
         return self._impl.size
 
+    def empty(self) -> bool:
+        return self._impl.empty()
+
     def reset(self) -> None:
         self._impl.reset()
 
     def clear(self) -> None:
         self._impl.clear()
+
+    def front(self) -> Tuple[KeyType, ValueType]:
+        return self._impl.front()
+
+    def back(self) -> Tuple[KeyType, ValueType]:
+        return self._impl.back()
+
+    def at(self, index: IndexType) -> Tuple[KeyType, ValueType]:
+        return self._impl.at(index)
+
+    def get(self, key: KeyType) -> ValueType:
+        return self._impl.get(key)
 
     def append(self, data: NestedTensor) -> Tuple[int, Optional[int]]:
         return self._impl.append(data)

--- a/tests/core/replay_buffer_test.py
+++ b/tests/core/replay_buffer_test.py
@@ -63,15 +63,15 @@ class ReplayBufferTest(TestCaseBase):
         count = torch.bincount(keys)
         self.assertEqual(count.max().item(), 1)
         count = torch.zeros(self.batch_size, dtype=torch.int64)
-        for _ in range(10000):
-            keys, _, _ = self.replay_buffer.sample(2)
+        for _ in range(20000):
+            keys, _, _ = self.replay_buffer.sample(3)
             count[keys] += 1
         actual_probs = count / count.sum()
         expected_probs = torch.full_like(actual_probs, prob)
         self.assert_tensor_close(actual_probs, expected_probs, atol=0.05)
 
         # Test sample with replacement.
-        num_samples = 10000
+        num_samples = 20000
         keys, _, probs = self.replay_buffer.sample(num_samples,
                                                    replacement=True)
         self.assert_tensor_equal(
@@ -134,18 +134,21 @@ class PrioritizedReplayBufferTest(TestCaseBase):
         # Test sample without replacement
         num_samples = self.batch_size
         keys, _, probs = replay_buffer.sample(num_samples)
-        self.assert_tensor_close(probs, expected_probs[keys], rtol=1e-6)
+        self.assert_tensor_close(probs,
+                                 expected_probs[keys],
+                                 rtol=1e-6,
+                                 atol=1e-6)
         count = torch.bincount(keys)
         self.assertEqual(count.max().item(), 1)
         count = torch.zeros(self.batch_size, dtype=torch.int64)
-        for _ in range(10000):
-            keys, _, _ = replay_buffer.sample(2)
+        for _ in range(100000):
+            keys, _, _ = replay_buffer.sample(3)
             count[keys] += 1
         actual_probs = count / count.sum()
         self.assert_tensor_close(actual_probs, expected_probs, atol=0.1)
 
         # Test sample with replacement.
-        num_samples = 1000
+        num_samples = 100000
         keys, _, probs = replay_buffer.sample(num_samples, replacement=True)
         actual_probs = torch.bincount(keys).float() / num_samples
         self.assert_tensor_close(probs, expected_probs[keys], rtol=1e-6)

--- a/tests/core/replay_buffer_test.py
+++ b/tests/core/replay_buffer_test.py
@@ -37,7 +37,7 @@ class ReplayBufferTest(TestCaseBase):
         expected_keys = torch.arange(self.batch_size)
         self.assertEqual(len(self.replay_buffer), self.batch_size)
         self.assert_tensor_equal(keys, expected_keys)
-        data = self.replay_buffer[keys]
+        data = self.replay_buffer.get(keys)
         self.assertEqual(data.keys(), self.flatten_data.keys())
         for k, v in data.items():
             self.assert_tensor_equal(v, self.flatten_data[k])
@@ -45,7 +45,7 @@ class ReplayBufferTest(TestCaseBase):
         keys = self.replay_buffer.extend(self.data)
         self.assertEqual(len(self.replay_buffer), self.size)
         self.assert_tensor_equal(keys, expected_keys + self.batch_size)
-        data = self.replay_buffer[keys]
+        data = self.replay_buffer.get(keys)
         self.assertEqual(data.keys(), self.flatten_data.keys())
         for k, v in data.items():
             self.assert_tensor_equal(v, self.flatten_data[k])
@@ -111,7 +111,7 @@ class PrioritizedReplayBufferTest(TestCaseBase):
         expected_keys = torch.arange(self.batch_size)
         self.assertEqual(len(replay_buffer), self.batch_size)
         self.assert_tensor_equal(keys, expected_keys)
-        data = replay_buffer[keys]
+        data = replay_buffer.get(keys)
         self.assertEqual(data.keys(), self.flatten_data.keys())
         for k, v in data.items():
             self.assert_tensor_equal(v, self.flatten_data[k])
@@ -119,7 +119,7 @@ class PrioritizedReplayBufferTest(TestCaseBase):
         keys = replay_buffer.extend(self.data)
         self.assertEqual(len(replay_buffer), self.size)
         self.assert_tensor_equal(keys, expected_keys + self.batch_size)
-        data = replay_buffer[keys]
+        data = replay_buffer.get(keys)
         self.assertEqual(data.keys(), self.flatten_data.keys())
         for k, v in data.items():
             self.assert_tensor_equal(v, self.flatten_data[k])


### PR DESCRIPTION
This PR changed the behavior of APIs in CircularBuffer.
1. Change at method to select keys and values based on indices in the CircularBuffer.
2. Add get method to select values based on the keys.
3. Add front() method to get the 1st key and value in the CircularBuffer, which is equivalent to buffer.at(0)
4. Add back() method to get the last key and value in the CircularBuffer, which is equivalent toe buffer.at(-1)