### PR TITLE
Add groupby op to support multi-version model inference

### DIFF
--- a/rlmeta/CMakeLists.txt
+++ b/rlmeta/CMakeLists.txt
@@ -51,6 +51,8 @@ add_subdirectory(
 pybind11_add_module(
   _rlmeta_extension
   ${CMAKE_CURRENT_SOURCE_DIR}/cc/nested_utils/nested_utils.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/cc/ops/groupby.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/cc/ops/ops.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/cc/pybind.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/cc/samplers/prioritized_sampler.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/cc/samplers/sampler.cc

--- a/rlmeta/cc/ops/groupby.cc
+++ b/rlmeta/cc/ops/groupby.cc
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "rlmeta/cc/ops/groupby.h"
+
+#include <algorithm>
+#include <cassert>
+
+#include "rlmeta/cc/utils/torch_utils.h"
+
+namespace rlmeta {
+namespace ops {
+
+namespace {
+
+template <typename T>
+void GroupByImpl(const torch::Tensor& x,
+                 std::vector<std::pair<torch::Tensor, torch::Tensor>>& result) {
+  assert(x.dim() == 1);
+  const torch::Tensor x_contiguous = x.contiguous();
+  const int64_t n = x_contiguous.numel();
+  const T* x_data = x_contiguous.data_ptr<T>();
+  if (n == 0) {
+    return;
+  }
+  std::vector<std::pair<T, int64_t>> data;
+  data.reserve(n);
+  for (int64_t i = 0; i < n; ++i) {
+    data.emplace_back(x_data[i], i);
+  }
+  std::sort(data.begin(), data.end());
+  result.clear();
+  result.reserve(n);
+  std::vector<int64_t> indices;
+  T key = data[0].first;
+  indices.push_back(data[0].second);
+  for (int i = 1; i < n; ++i) {
+    auto [k, v] = data[i];
+    if (k != key) {
+      result.emplace_back(torch::tensor(key, utils::TorchDataType<T>::value),
+                          utils::AsTorchTensor(std::move(indices)));
+      key = k;
+    }
+    indices.push_back(v);
+  }
+  if (!indices.empty()) {
+    result.emplace_back(torch::tensor(key, utils::TorchDataType<T>::value),
+                        utils::AsTorchTensor(std::move(indices)));
+  }
+}
+
+}  // namespace
+
+std::vector<std::pair<torch::Tensor, torch::Tensor>> GroupBy(
+    const torch::Tensor& x) {
+  std::vector<std::pair<torch::Tensor, torch::Tensor>> ret;
+  AT_DISPATCH_ALL_TYPES_AND(torch::kBool, x.scalar_type(), "GroupBy",
+                            [&]() { GroupByImpl<scalar_t>(x, ret); });
+  return ret;
+}
+
+void DefineGroupByOp(py::module& m) {
+  m.def("groupby", [](const torch::Tensor& x) {
+    std::vector<std::pair<torch::Tensor, torch::Tensor>> vec = GroupBy(x);
+    const int64_t n = vec.size();
+    py::tuple ret(n);
+    for (int i = 0; i < n; ++i) {
+      ret[i] =
+          py::make_tuple(std::move(vec[i].first), std::move(vec[i].second));
+    }
+    return ret;
+  });
+}
+
+}  // namespace ops
+}  // namespace rlmeta

--- a/rlmeta/cc/ops/groupby.h
+++ b/rlmeta/cc/ops/groupby.h
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <torch/extension.h>
+#include <torch/torch.h>
+
+#include <utility>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace rlmeta {
+namespace ops {
+
+std::vector<std::pair<torch::Tensor, torch::Tensor>> GroupBy(
+    const torch::Tensor& x);
+
+void DefineGroupByOp(py::module& m);
+
+}  // namespace ops
+}  // namespace rlmeta

--- a/rlmeta/cc/ops/groupby.h
+++ b/rlmeta/cc/ops/groupby.h
@@ -17,7 +17,7 @@ namespace py = pybind11;
 namespace rlmeta {
 namespace ops {
 
-std::vector<std::pair<torch::Tensor, torch::Tensor>> GroupBy(
+std::pair<torch::Tensor, std::vector<torch::Tensor>> GroupBy(
     const torch::Tensor& x);
 
 void DefineGroupByOp(py::module& m);

--- a/rlmeta/cc/ops/ops.cc
+++ b/rlmeta/cc/ops/ops.cc
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "rlmeta/cc/ops/ops.h"
+
+#include "rlmeta/cc/ops/groupby.h"
+
+namespace rlmeta {
+
+void DefineOps(py::module& m) {
+  py::module sub =
+      m.def_submodule("ops", "ops submodule of \"_rlmeta_extension\"");
+
+  ops::DefineGroupByOp(sub);
+}
+
+}  // namespace rlmeta

--- a/rlmeta/cc/ops/ops.h
+++ b/rlmeta/cc/ops/ops.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace rlmeta {
+
+void DefineOps(py::module& m);
+
+}  // namespace rlmeta

--- a/rlmeta/cc/pybind.cc
+++ b/rlmeta/cc/pybind.cc
@@ -6,6 +6,7 @@
 #include <pybind11/pybind11.h>
 
 #include "rlmeta/cc/nested_utils/nested_utils.h"
+#include "rlmeta/cc/ops/ops.h"
 #include "rlmeta/cc/samplers/prioritized_sampler.h"
 #include "rlmeta/cc/samplers/sampler.h"
 #include "rlmeta/cc/samplers/uniform_sampler.h"
@@ -29,6 +30,8 @@ PYBIND11_MODULE(_rlmeta_extension, m) {
   rlmeta::DefineSampler(m);
   rlmeta::DefineUniformSampler(m);
   rlmeta::DefinePrioritizedSampler(m);
+
+  rlmeta::DefineOps(m);
 }
 
 }  // namespace

--- a/rlmeta/cc/utils/numpy_utils.h
+++ b/rlmeta/cc/utils/numpy_utils.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 namespace py = pybind11;

--- a/rlmeta/cc/utils/torch_utils.h
+++ b/rlmeta/cc/utils/torch_utils.h
@@ -11,6 +11,8 @@
 #include <torch/torch.h>
 
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace py = pybind11;
 
@@ -23,6 +25,21 @@ struct TorchDataType;
 template <>
 struct TorchDataType<bool> {
   static constexpr torch::ScalarType value = torch::kBool;
+};
+
+template <>
+struct TorchDataType<uint8_t> {
+  static constexpr torch::ScalarType value = torch::kUInt8;
+};
+
+template <>
+struct TorchDataType<int8_t> {
+  static constexpr torch::ScalarType value = torch::kInt8;
+};
+
+template <>
+struct TorchDataType<int16_t> {
+  static constexpr torch::ScalarType value = torch::kInt16;
 };
 
 template <>
@@ -55,6 +72,22 @@ inline torch::Tensor PyObjectToTorchTensor(const py::object& obj) {
 
 inline py::object TorchTensorToPyObject(const torch::Tensor& tensor) {
   return py::reinterpret_steal<py::object>(THPVariable_Wrap(tensor));
+}
+
+template <typename T>
+torch::Tensor AsTorchTensor(const std::vector<T>& vec) {
+  return torch::tensor(vec);
+}
+
+template <typename T>
+torch::Tensor AsTorchTensor(std::vector<T>&& vec) {
+  const int64_t size = vec.size();
+  T* data = vec.data();
+  std::unique_ptr<std::vector<T>> vec_ptr =
+      std::make_unique<std::vector<T>>(std::move(vec));
+  return torch::from_blob(
+      data, {size}, [ptr = vec_ptr.release()](void* /*p*/) { delete ptr; },
+      TorchDataType<T>::value);
 }
 
 }  // namespace utils

--- a/rlmeta/ops/__init__.py
+++ b/rlmeta/ops/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from _rlmeta_extension.ops import *


### PR DESCRIPTION
This PR add a groupby op to group the indices of input tensor by values.

Example:
```
x = torch.tensor([0, 0, 1, 2, 1])
values, groups = rlmeta.ops.groupby(x)
# values: tensor([0, 1, 2])
# groups: (tensor([0, 1]), tensor([2, 4]), tensor([3]))
```
