### PR TITLE
Add ModelPool to support different version of models

### DIFF
--- a/examples/atari/dqn/atari_apex_dqn.py
+++ b/examples/atari/dqn/atari_apex_dqn.py
@@ -22,7 +22,8 @@ from rlmeta.agents.dqn import (ApexDQNAgent, ApexDQNAgentFactory,
                                ConstantEpsFunc, FlexibleEpsFunc)
 from rlmeta.core.controller import Phase, Controller
 from rlmeta.core.loop import LoopList, ParallelLoop
-from rlmeta.core.model import wrap_downstream_model
+from rlmeta.core.model import ModelVersion, RemotableModelPool
+from rlmeta.core.model import make_remote_model, wrap_downstream_model
 from rlmeta.core.replay_buffer import ReplayBuffer, make_remote_replay_buffer
 from rlmeta.core.server import Server, ServerList
 from rlmeta.samplers import PrioritizedSampler
@@ -37,11 +38,10 @@ def main(cfg):
 
     env = atari_wrappers.make_atari(cfg.env)
     train_model = AtariDQNModel(env.action_space.n).to(cfg.train_device)
+    infer_model = copy.deepcopy(train_model).to(cfg.infer_device)
     loss = get_loss(cfg.loss.name)
     optimizer = get_optimizer(cfg.optimizer.name, train_model.parameters(),
                               cfg.optimizer.args)
-
-    infer_model = copy.deepcopy(train_model).to(cfg.infer_device)
 
     ctrl = Controller()
     rb = ReplayBuffer(
@@ -51,14 +51,19 @@ def main(cfg):
     m_server = Server(cfg.m_server_name, cfg.m_server_addr)
     r_server = Server(cfg.r_server_name, cfg.r_server_addr)
     c_server = Server(cfg.c_server_name, cfg.c_server_addr)
-    m_server.add_service(infer_model)
+    m_server.add_service(RemotableModelPool(infer_model))
     r_server.add_service(rb)
     c_server.add_service(ctrl)
     servers = ServerList([m_server, r_server, c_server])
 
     a_model = wrap_downstream_model(train_model, m_server)
-    t_model = remote_utils.make_remote(infer_model, m_server)
-    e_model = remote_utils.make_remote(infer_model, m_server)
+    t_model = make_remote_model(infer_model,
+                                m_server,
+                                version=ModelVersion.LATEST)
+    # During blocking evaluation we have STABLE is LATEST
+    e_model = make_remote_model(infer_model,
+                                m_server,
+                                version=ModelVersion.LATEST)
 
     a_ctrl = remote_utils.make_remote(ctrl, c_server)
     t_ctrl = remote_utils.make_remote(ctrl, c_server)
@@ -139,9 +144,9 @@ def main(cfg):
         else:
             logging.info(
                 stats.json(info, phase="Eval", epoch=epoch, time=cur_time))
-        time.sleep(1)
 
         torch.save(train_model.state_dict(), f"dqn_agent-{epoch}.pth")
+        time.sleep(1)
 
     loops.terminate()
     servers.terminate()

--- a/examples/atari/ppo/atari_ppo.py
+++ b/examples/atari/ppo/atari_ppo.py
@@ -23,7 +23,8 @@ from rlmeta.agents.agent import AgentFactory
 from rlmeta.agents.ppo import PPOAgent
 from rlmeta.core.controller import Phase, Controller
 from rlmeta.core.loop import LoopList, ParallelLoop
-from rlmeta.core.model import wrap_downstream_model
+from rlmeta.core.model import ModelVersion, RemotableModelPool
+from rlmeta.core.model import make_remote_model, wrap_downstream_model
 from rlmeta.core.replay_buffer import ReplayBuffer, make_remote_replay_buffer
 from rlmeta.core.server import Server, ServerList
 from rlmeta.samplers import UniformSampler
@@ -37,10 +38,9 @@ def main(cfg):
 
     env = atari_wrappers.make_atari(cfg.env)
     train_model = AtariPPOModel(env.action_space.n).to(cfg.train_device)
+    infer_model = copy.deepcopy(train_model).to(cfg.infer_device)
     optimizer = get_optimizer(cfg.optimizer.name, train_model.parameters(),
                               cfg.optimizer.args)
-
-    infer_model = copy.deepcopy(train_model).to(cfg.infer_device)
 
     ctrl = Controller()
     rb = ReplayBuffer(TensorCircularBuffer(cfg.replay_buffer_size),
@@ -49,14 +49,19 @@ def main(cfg):
     m_server = Server(cfg.m_server_name, cfg.m_server_addr)
     r_server = Server(cfg.r_server_name, cfg.r_server_addr)
     c_server = Server(cfg.c_server_name, cfg.c_server_addr)
-    m_server.add_service(infer_model)
+    m_server.add_service(RemotableModelPool(infer_model))
     r_server.add_service(rb)
     c_server.add_service(ctrl)
     servers = ServerList([m_server, r_server, c_server])
 
     a_model = wrap_downstream_model(train_model, m_server)
-    t_model = remote_utils.make_remote(infer_model, m_server)
-    e_model = remote_utils.make_remote(infer_model, m_server)
+    t_model = make_remote_model(infer_model,
+                                m_server,
+                                version=ModelVersion.LATEST)
+    # During blocking evaluation we have STABLE is LATEST
+    e_model = make_remote_model(infer_model,
+                                m_server,
+                                version=ModelVersion.LATEST)
 
     a_ctrl = remote_utils.make_remote(ctrl, c_server)
     t_ctrl = remote_utils.make_remote(ctrl, c_server)
@@ -120,9 +125,9 @@ def main(cfg):
         else:
             logging.info(
                 stats.json(info, phase="Eval", epoch=epoch, time=cur_time))
-        time.sleep(1)
 
         torch.save(train_model.state_dict(), f"ppo_agent-{epoch}.pth")
+        time.sleep(1)
 
     loops.terminate()
     servers.terminate()

--- a/rlmeta/agents/agent.py
+++ b/rlmeta/agents/agent.py
@@ -7,7 +7,8 @@ import abc
 import asyncio
 import copy
 
-from typing import Any, Optional, Type
+from concurrent.futures import Future
+from typing import Any, Optional, Type, Union
 
 import rlmeta.core.remote as remote
 import rlmeta.utils.moolib_utils as moolib_utils
@@ -77,10 +78,15 @@ class Agent(abc.ABC):
             if isinstance(obj, remote.Remote):
                 obj.connect()
 
-    def train(self, num_steps: int) -> Optional[StatsDict]:
+    def train(self,
+              num_steps: int,
+              keep_evaluation_loops: bool = False) -> StatsDict:
         pass
 
-    def eval(self, num_episodes: int) -> Optional[StatsDict]:
+    def eval(self,
+             num_episodes: int,
+             keep_training_loops: bool = False,
+             non_blocking: bool = False) -> Union[StatsDict, Future]:
         pass
 
 

--- a/rlmeta/agents/dqn/apex_dqn_agent.py
+++ b/rlmeta/agents/dqn/apex_dqn_agent.py
@@ -212,16 +212,6 @@ class ApexDQNAgent(Agent):
         return self._eval_executor.submit(self._eval, num_episodes,
                                           keep_training_loops)
 
-        # if keep_training_loops:
-        #     self._controller.set_phase(Phase.BOTH)
-        # else:
-        #     self._controller.set_phase(Phase.EVAL)
-        # self._controller.reset_phase(Phase.EVAL, limit=num_episodes)
-        # while self._controller.count(Phase.EVAL) < num_episodes:
-        #     time.sleep(1)
-        # stats = self._controller.stats(Phase.EVAL)
-        # return stats
-
     def _make_replay(self) -> Optional[List[NestedTensor]]:
         trajectory_len = len(self._trajectory)
         if trajectory_len < 2:

--- a/rlmeta/agents/ppo/ppo_rnd_agent.py
+++ b/rlmeta/agents/ppo/ppo_rnd_agent.py
@@ -15,7 +15,7 @@ from rlmeta.agents.ppo.ppo_agent import PPOAgent
 from rlmeta.core.controller import ControllerLike
 from rlmeta.core.model import ModelLike
 from rlmeta.core.replay_buffer import ReplayBufferLike
-from rlmeta.core.rescalers import Rescaler, MomentsRescaler, RMSRescaler
+from rlmeta.core.rescalers import StdRescaler
 from rlmeta.core.types import Action, TimeStep
 from rlmeta.core.types import Tensor, NestedTensor
 
@@ -56,9 +56,9 @@ class PPORNDAgent(PPOAgent):
         self._intrinsic_advantage_coeff = intrinsic_advantage_coeff
 
         self._reward_rescaler = None
-        self._ext_reward_rescaler = RMSRescaler(
+        self._ext_reward_rescaler = StdRescaler(
             size=1) if rescale_reward else None
-        self._int_reward_rescaler = RMSRescaler(
+        self._int_reward_rescaler = StdRescaler(
             size=1) if rescale_reward else None
 
         self._collate_fn = torch.stack if collate_fn is None else collate_fn
@@ -173,7 +173,8 @@ class PPORNDAgent(PPOAgent):
         return int_rewards
 
     def _train_step(self, batch: NestedTensor) -> Dict[str, float]:
-        batch = nested_utils.map_nested(lambda x: x.to(self.device()), batch)
+        batch = nested_utils.map_nested(lambda x: x.to(self._model.device),
+                                        batch)
         self._optimizer.zero_grad()
 
         obs = batch["obs"]

--- a/rlmeta/core/model.py
+++ b/rlmeta/core/model.py
@@ -3,29 +3,81 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict, Optional, Union
+import copy
+import functools
+
+from enum import IntEnum
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 
 import torch
 import torch.nn as nn
 
 import rlmeta.core.remote as remote
+import rlmeta.ops as rlmeta_ops
+import rlmeta.utils.data_utils as data_utils
 import rlmeta.utils.nested_utils as nested_utils
 
+from rlmeta.core.launchable import Launchable
 from rlmeta.core.server import Server
+from rlmeta.core.types import NestedTensor
+from rlmeta.samplers import UniformSampler
+from rlmeta.storage.circular_buffer import CircularBuffer
+
+
+class ModelVersion(IntEnum):
+    # Use negative values for special version flag to avoid conflict with real
+    # version.
+    LATEST = -1
+    STABLE = -2
+    RANDOM = -3
 
 
 class RemotableModel(nn.Module, remote.Remotable):
 
-    def __init__(self, identifier: Optional[str] = None):
+    def __init__(self, identifier: Optional[str] = None) -> None:
         nn.Module.__init__(self)
         remote.Remotable.__init__(self, identifier)
 
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
+
+
+class RemotableModelPool(remote.Remotable, Launchable):
+
+    def __init__(self,
+                 model: RemotableModel,
+                 capacity: int = 1,
+                 identifier: Optional[str] = None) -> None:
+        super().__init__(identifier)
+
+        self._model = model
+        self._capacity = capacity
+        self._history = CircularBuffer(self._capacity)
+        self._sampler = UniformSampler()
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
     def init_launching(self) -> None:
-        self.share_memory()
+        self._model.share_memory()
+
+    def init_execution(self) -> None:
+        self._bind()
+
+    def model(self, version: int = ModelVersion.LATEST) -> nn.Module:
+        if version == ModelVersion.LATEST:
+            return self._model
+        elif version == ModelVersion.STABLE:
+            return self._history.back()[1]
+        else:
+            return self._history.get(version)
 
     @remote.remote_method(batch_size=None)
-    def pull(self) -> Dict[str, torch.Tensor]:
-        state_dict = self.state_dict()
+    def pull(self,
+             version: int = ModelVersion.LATEST) -> Dict[str, torch.Tensor]:
+        state_dict = self.model(version).state_dict()
         state_dict = nested_utils.map_nested(lambda x: x.cpu(), state_dict)
         return state_dict
 
@@ -33,9 +85,147 @@ class RemotableModel(nn.Module, remote.Remotable):
     def push(self, state_dict: Dict[str, torch.Tensor]) -> None:
         # Move state_dict to device before loading.
         # https://github.com/pytorch/pytorch/issues/34880
-        device = next(self.parameters()).device
+        device = self._model.device
         state_dict = nested_utils.map_nested(lambda x: x.to(device), state_dict)
-        self.load_state_dict(state_dict)
+        self._model.load_state_dict(state_dict)
+
+    @remote.remote_method(batch_size=None)
+    def release(self) -> None:
+        new_key, old_key = self._history.append(copy.deepcopy(self._model))
+        self._sampler.insert(new_key, 1.0)
+        if old_key is not None:
+            self._sampler.delete(old_key)
+
+    @remote.remote_method(batch_size=None)
+    def sample_model(self,
+                     num_samples: int = 1,
+                     replacement: bool = False) -> torch.Tensor:
+        ret, _ = self._sampler.sample(num_samples, replacement)
+        return torch.from_numpy(ret)
+
+    def _bind(self) -> None:
+        for method in self._model.remote_methods:
+            self.__remote_methods__.append(method)
+            batch_size = getattr(getattr(self._model, method), "__batch_size__",
+                                 None)
+            setattr(self, method, self._wrap_remote_method(method, batch_size))
+
+    def _wrap_remote_method(
+            self,
+            method: str,
+            batch_size: Optional[int] = None) -> Callable[..., Any]:
+
+        def wrapped_method(version: torch.Tensor, *args, **kwargs) -> Any:
+            return self._dispatch_method_by_version(version, method, *args,
+                                                    **kwargs)
+
+        setattr(wrapped_method, "__remote__", True)
+        if batch_size is not None:
+            setattr(wrapped_method, "__batch_size__", batch_size)
+
+        return wrapped_method
+
+    def _dispatch_method_by_version(self, version: torch.Tensor, method: str,
+                                    *args, **kwargs) -> Any:
+        version = version.view(-1)
+        batch_size = version.numel()
+        random_mask = (version == ModelVersion.RANDOM)
+        if random_mask.any():
+            random_version, _ = self._sampler.sample(batch_size,
+                                                     replacement=True)
+            random_version = torch.from_numpy(random_version)
+            version = torch.where(random_mask, random_version, version)
+
+        values, groups = rlmeta_ops.groupby(version)
+        values = values.tolist()
+
+        device = self._model.device
+        args = nested_utils.map_nested(lambda x: x.to(device), args)
+        kwargs = nested_utils.map_nested(lambda x: x.to(device), kwargs)
+        groups = tuple([g.to(device) for g in groups])
+
+        if len(values) == 1:
+            ret = self._call_single_model(values[0], method, *args, **kwargs)
+            ret = nested_utils.map_nested(lambda x: x.cpu(), ret)
+            return ret
+
+        rets = []
+        for v, g in zip(values, groups):
+            cur_args = nested_utils.map_nested(
+                lambda x: self._index_select_data(x, index=g), args)
+            cur_kwargs = nested_utils.map_nested(
+                lambda x: self._index_select_data(x, index=g), kwargs)
+            ret = self._call_single_model(v, method, *cur_args, *cur_kwargs)
+            rets.append(ret)
+        index = torch.cat(groups)
+        index = torch.argsort(index)
+        ret = data_utils.cat_fields(rets)
+        ret = nested_utils.map_nested(
+            lambda x: x.index_select(dim=0, index=index).cpu(), ret)
+
+        return ret
+
+    def _call_single_model(self, version: int, method: str, *args,
+                           **kwargs) -> Any:
+        model = self.model(version)
+        return getattr(model, method)(*args, **kwargs)
+
+    def _index_select_data(
+            self, data: Union[torch.Tensor, Sequence[NestedTensor]],
+            index: torch.Tensor) -> Union[torch.Tensor, Tuple[NestedTensor]]:
+        if isinstance(data, torch.Tensor):
+            return data.index_select(dim=0, index=index)
+        else:
+            # For Non-tensor data.
+            return tuple([data[i] for i in index.tolist()])
+
+
+class RemoteModel(remote.Remote):
+
+    def __init__(self,
+                 target: RemotableModel,
+                 server_name: str,
+                 server_addr: str,
+                 name: Optional[str] = None,
+                 version: int = ModelVersion.LATEST,
+                 timeout: float = 60) -> None:
+        # Define self._version before self._bind in __init__.
+        self._version = torch.tensor([version])
+        super().__init__(target, server_name, server_addr, name, timeout)
+
+    @property
+    def version(self) -> int:
+        return self._version.item()
+
+    @version.setter
+    def version(self, version: int) -> None:
+        self._version = torch.tensor([version])
+        # Bind _remote_methods again for new version.
+        self._bind()
+
+    def sample_model(self,
+                     num_samples: int = 1,
+                     replacement: bool = False) -> torch.Tensor:
+        return self.client.sync(self.server_name,
+                                self.remote_method_name("sample_model"),
+                                num_samples, replacement)
+
+    async def async_sample_model(self,
+                                 num_samples: int = 1,
+                                 replacement: bool = False) -> torch.Tensor:
+        return await self.client.async_(self.server_name,
+                                        self.remote_method_name("sample_model"),
+                                        num_samples, replacement)
+
+    def _bind(self) -> None:
+        for method in self._remote_methods:
+            method_name = self.remote_method_name(method)
+
+            self._client_methods[method] = functools.partial(
+                self.client.sync, self.server_name, method_name, self._version)
+            self._client_methods["async_" + method] = functools.partial(
+                self.client.async_, self.server_name, method_name,
+                self._version)
 
 
 class DownstreamModel(remote.Remote):
@@ -63,14 +253,15 @@ class DownstreamModel(remote.Remote):
     def __call__(self, *args, **kwargs) -> Any:
         return self.wrapped(*args, **kwargs)
 
-    def pull(self) -> None:
+    def pull(self, version: int = ModelVersion.LATEST) -> None:
         state_dict = self.client.sync(self.server_name,
-                                      self.remote_method_name("pull"))
+                                      self.remote_method_name("pull"), version)
         self.wrapped.load_state_dict(state_dict)
 
-    async def async_pull(self) -> None:
+    async def async_pull(self, version: int = ModelVersion.LATEST) -> None:
         state_dict = await self.client.async_(self.server_name,
-                                              self.remote_method_name("pull"))
+                                              self.remote_method_name("pull"),
+                                              version)
         self.wrapped.load_state_dict(state_dict)
 
     def push(self) -> None:
@@ -85,14 +276,44 @@ class DownstreamModel(remote.Remote):
         await self.client.async_(self.server_name,
                                  self.remote_method_name("push"), state_dict)
 
+    def release(self) -> None:
+        self.client.sync(self.server_name, self.remote_method_name("release"))
+
+    async def async_release(self) -> None:
+        await self.client.async_(self.server_name,
+                                 self.remote_method_name("release"))
+
+    def sample_model(self,
+                     num_samples: int = 1,
+                     replacement: bool = False) -> torch.Tensor:
+        return self.client.sync(self.server_name,
+                                self.remote_method_name("sample_model"),
+                                num_samples, replacement)
+
+    async def async_sample_model(self,
+                                 num_samples: int = 1,
+                                 replacement: bool = False) -> torch.Tensor:
+        return await self.client.async_(self.server_name,
+                                        self.remote_method_name("sample_model"),
+                                        num_samples, replacement)
+
     def _bind(self) -> None:
         pass
 
 
-ModelLike = Union[nn.Module, RemotableModel, DownstreamModel, remote.Remote]
+ModelLike = Union[nn.Module, RemotableModel, RemoteModel, DownstreamModel,
+                  remote.Remote]
 
 
-def wrap_downstream_model(model: nn.Module,
+def make_remote_model(model: RemotableModel,
+                      server: Server,
+                      name: Optional[str] = None,
+                      version: int = ModelVersion.LATEST,
+                      timeout: float = 60) -> RemoteModel:
+    return RemoteModel(model, server.name, server.addr, name, version, timeout)
+
+
+def wrap_downstream_model(model: RemotableModel,
                           server: Server,
                           name: Optional[str] = None,
                           timeout: float = 60) -> DownstreamModel:

--- a/rlmeta/core/remote.py
+++ b/rlmeta/core/remote.py
@@ -139,17 +139,16 @@ class Remote:
 
     def _bind(self) -> None:
         for method in self._remote_methods:
+            method_name = self.remote_method_name(method)
             self._client_methods[method] = functools.partial(
-                self.client.sync, self.server_name,
-                self.remote_method_name(method))
+                self.client.sync, self.server_name, method_name)
             self._client_methods["async_" + method] = functools.partial(
-                self.client.async_, self.server_name,
-                self.remote_method_name(method))
+                self.client.async_, self.server_name, method_name)
 
 
 def remote_method(batch_size: Optional[int] = None) -> Callable[..., Any]:
 
-    def remote_method_impl(func: Callable[..., Any]):
+    def remote_method_impl(func: Callable[..., Any]) -> Callable[..., Any]:
         setattr(func, "__remote__", True)
         setattr(func, "__batch_size__", batch_size)
         return func


### PR DESCRIPTION
This PR added ModelPool to support different version of models. This can also support non-blocking evaluation to save total training time.