### PR TITLE
Improve Ape-X DQN Implementation

### DIFF
--- a/examples/atari/dqn/atari_apex_dqn.py
+++ b/examples/atari/dqn/atari_apex_dqn.py
@@ -40,10 +40,11 @@ def main(cfg):
     env = atari_wrapper.make_atari_env(**cfg.env)
     model = AtariDQNModel(env.action_space.n,
                           network=cfg.network,
+                          dueling_dqn=cfg.dueling_dqn,
+                          spectral_norm=cfg.spectral_norm,
                           double_dqn=cfg.double_dqn).to(cfg.train_device)
-    # model_pool = RemotableModelPool(copy.deepcopy(model).to(cfg.infer_device),
-    #                                 seed=cfg.seed)
     infer_model = copy.deepcopy(model).to(cfg.infer_device)
+    # Disable eval mode because there are some issues for SpectralNorm.
     # infer_model.eval()
     model_pool = RemotableModelPool(infer_model, seed=cfg.seed)
     optimizer = make_optimizer(model.parameters(), **cfg.optimizer)

--- a/examples/atari/dqn/atari_apex_dqn.py
+++ b/examples/atari/dqn/atari_apex_dqn.py
@@ -41,8 +41,11 @@ def main(cfg):
     model = AtariDQNModel(env.action_space.n,
                           network=cfg.network,
                           double_dqn=cfg.double_dqn).to(cfg.train_device)
-    model_pool = RemotableModelPool(copy.deepcopy(model).to(cfg.infer_device),
-                                    seed=cfg.seed)
+    # model_pool = RemotableModelPool(copy.deepcopy(model).to(cfg.infer_device),
+    #                                 seed=cfg.seed)
+    infer_model = copy.deepcopy(model).to(cfg.infer_device)
+    # infer_model.eval()
+    model_pool = RemotableModelPool(infer_model, seed=cfg.seed)
     optimizer = make_optimizer(model.parameters(), **cfg.optimizer)
 
     replay_buffer = ReplayBuffer(
@@ -114,10 +117,12 @@ def main(cfg):
         controller=learner_ctrl,
         optimizer=optimizer,
         batch_size=cfg.batch_size,
+        max_grad_norm=cfg.max_grad_norm,
         n_step=cfg.n_step,
         gamma=cfg.gamma,
         importance_sampling_exponent=cfg.importance_sampling_exponent,
         value_clipping_eps=cfg.value_clipping_eps,
+        fr_kappa=cfg.fr_kappa,
         target_sync_period=cfg.target_sync_period,
         learning_starts=cfg.learning_starts,
         model_push_period=cfg.model_push_period)
@@ -125,6 +130,8 @@ def main(cfg):
     servers.start()
     loops.start()
     learner.connect()
+    learner_model.init_model()
+    learner_model.push()
 
     start_time = time.perf_counter()
     for epoch in range(cfg.num_epochs):

--- a/examples/atari/dqn/atari_dqn_model.py
+++ b/examples/atari/dqn/atari_dqn_model.py
@@ -47,11 +47,15 @@ class AtariDQNNet(nn.Module):
 
     def init_model(self) -> None:
         if self._spectral_norm:
-            # Apply SN[-2] in https://arxiv.org/pdf/2105.05246.pdf
-            nn.utils.parametrizations.spectral_norm(
-                self._head._mlp_a._layers[-3])
-            nn.utils.parametrizations.spectral_norm(
-                self._head._mlp_v._layers[-3])
+            # Apply SN[-2] in https://arxiv.org/abs/2105.05246
+            if self._dueling_dqn:
+                nn.utils.parametrizations.spectral_norm(
+                    self._head._mlp_a._layers[-3])
+                nn.utils.parametrizations.spectral_norm(
+                    self._head._mlp_v._layers[-3])
+            else:
+                nn.utils.parametrizations.spectral_norm(
+                    self._head._mlp._layers[-3])
 
     def forward(self, observation: torch.Tensor) -> torch.Tensor:
         x = observation.float() / 255.0

--- a/examples/atari/dqn/conf/conf_apex_dqn.yaml
+++ b/examples/atari/dqn/conf/conf_apex_dqn.yaml
@@ -24,7 +24,7 @@ table_view: False
 num_training_rollouts: 32
 num_training_workers: 16
 
-eps: 0.1
+eps: 0.4
 
 replay_buffer_size: 1000000
 priority_exponent: 0.6

--- a/examples/atari/dqn/conf/conf_apex_dqn.yaml
+++ b/examples/atari/dqn/conf/conf_apex_dqn.yaml
@@ -41,7 +41,7 @@ network: "nature"
 double_dqn: False
 target_sync_period: null
 
-gamma: 0.99
+gamma: 0.997
 n_step: 5
 
 batch_size: 512
@@ -51,7 +51,7 @@ model_push_period: 10
 
 optimizer:
   name: "Adam"
-  lr: 3e-4
+  lr: 1e-4
   eps: 1e-8
 
 num_epochs: 1000

--- a/examples/atari/dqn/conf/conf_apex_dqn.yaml
+++ b/examples/atari/dqn/conf/conf_apex_dqn.yaml
@@ -35,6 +35,7 @@ importance_sampling_exponent: 0.4
 max_abs_reward: null
 rescale_value: True
 value_clipping_eps: 0.2
+fr_kappa: 1.0
 
 network: "nature"
 double_dqn: False
@@ -44,6 +45,7 @@ gamma: 0.99
 n_step: 5
 
 batch_size: 512
+max_grad_norm: 40.0
 learning_starts: 65536
 model_push_period: 10
 

--- a/examples/atari/dqn/conf/conf_apex_dqn.yaml
+++ b/examples/atari/dqn/conf/conf_apex_dqn.yaml
@@ -21,14 +21,14 @@ seed: null
 table_view: False
 
 # Training configs.
-num_training_rollouts: 32
-num_training_workers: 16
+num_training_rollouts: 64
+num_training_workers: 32
 
 eps: 0.4
 
 replay_buffer_size: 1000000
 priority_exponent: 0.6
-prefetch: 2
+prefetch: 1
 
 importance_sampling_exponent: 0.4
 
@@ -37,7 +37,10 @@ rescale_value: True
 value_clipping_eps: 0.2
 fr_kappa: 1.0
 
-network: "nature"
+network: "impala"
+dueling_dqn: True
+spectral_norm: True
+
 double_dqn: False
 target_sync_period: null
 
@@ -51,7 +54,7 @@ model_push_period: 10
 
 optimizer:
   name: "Adam"
-  lr: 1e-4
+  lr: 3e-4
   eps: 1e-8
 
 num_epochs: 1000

--- a/rlmeta/agents/dqn/apex_dqn_agent.py
+++ b/rlmeta/agents/dqn/apex_dqn_agent.py
@@ -197,7 +197,6 @@ class ApexDQNAgent(Agent):
             t0 = time.perf_counter()
             keys, batch, probabilities = self._replay_buffer.sample(
                 self._batch_size)
-            # self._batch_size, replacement=True)
             t1 = time.perf_counter()
             step_stats = self._train_step(keys, batch, probabilities)
             t2 = time.perf_counter()

--- a/rlmeta/agents/dqn/apex_dqn_agent.py
+++ b/rlmeta/agents/dqn/apex_dqn_agent.py
@@ -475,11 +475,13 @@ class FlexibleEpsFunc:
     Eps function following https://arxiv.org/pdf/1805.11593.pdf.
     """
 
-    def __init__(self, eps: float, num: int) -> None:
+    def __init__(self, eps: float, num: int, alpha: float = 7.0) -> None:
         self._eps = eps
         self._num = num
+        self._alpha = alpha
 
     def __call__(self, index: int) -> float:
         if self._num == 1:
             return self._eps
-        return self._eps**(3.0 - 2.0 * (index / (self._num - 1)))
+        # return self._eps**(3.0 - 2.0 * (index / (self._num - 1)))
+        return self._eps**(1.0 + self._alpha * (index / (self._num - 1)))

--- a/rlmeta/agents/dqn/dqn_model.py
+++ b/rlmeta/agents/dqn/dqn_model.py
@@ -61,12 +61,6 @@ class DQNModel(RemotableModel):
         """
 
     @abc.abstractmethod
-    def compute_priority(self, observation: NestedTensor, action: torch.Tensor,
-                         target: torch.Tensor) -> torch.Tensor:
-        """
-        """
-
-    @abc.abstractmethod
     def sync_target_net(self) -> None:
         """
         """

--- a/rlmeta/core/loop.py
+++ b/rlmeta/core/loop.py
@@ -175,7 +175,7 @@ class AsyncLoop(Loop, Launchable):
                 await asyncio.sleep(1)
             stats = await self._run_episode(index, env, agent,
                                             episode_callbacks)
-            if stats is not None:
+            if self.running and stats is not None:
                 await self._controller.async_add_episode(
                     self._running_phase, stats)
 

--- a/rlmeta/core/model.py
+++ b/rlmeta/core/model.py
@@ -11,6 +11,8 @@ from enum import IntEnum
 from typing import (Any, Awaitable, Callable, Dict, Optional, Sequence, Tuple,
                     Union)
 
+from rich.console import Console
+
 import numpy as np
 
 import torch
@@ -27,6 +29,8 @@ from rlmeta.core.server import Server
 from rlmeta.core.types import NestedTensor
 from rlmeta.samplers import UniformSampler
 from rlmeta.storage.circular_buffer import CircularBuffer
+
+console = Console()
 
 
 class ModelVersion(IntEnum):
@@ -84,6 +88,7 @@ class RemotableModelPool(remote.Remotable, Launchable):
             random_utils.manual_seed(self._seed)
 
         self._model.init_model()
+        console.log(self._model)
 
     def model(self, version: int = ModelVersion.LATEST) -> nn.Module:
         return (self._model if version == ModelVersion.LATEST else

--- a/rlmeta/core/model.py
+++ b/rlmeta/core/model.py
@@ -84,7 +84,6 @@ class RemotableModelPool(remote.Remotable, Launchable):
             random_utils.manual_seed(self._seed)
 
         self._model.init_model()
-        print(self._model)
 
     def model(self, version: int = ModelVersion.LATEST) -> nn.Module:
         return (self._model if version == ModelVersion.LATEST else

--- a/rlmeta/core/model.py
+++ b/rlmeta/core/model.py
@@ -46,6 +46,9 @@ class RemotableModel(nn.Module, remote.Remotable):
     def device(self) -> torch.device:
         return next(self.parameters()).device
 
+    def init_model(self) -> None:
+        pass
+
 
 class RemotableModelPool(remote.Remotable, Launchable):
 
@@ -79,6 +82,9 @@ class RemotableModelPool(remote.Remotable, Launchable):
 
         if self._seed is not None:
             random_utils.manual_seed(self._seed)
+
+        self._model.init_model()
+        print(self._model)
 
     def model(self, version: int = ModelVersion.LATEST) -> nn.Module:
         return (self._model if version == ModelVersion.LATEST else

--- a/rlmeta/core/replay_buffer.py
+++ b/rlmeta/core/replay_buffer.py
@@ -8,7 +8,9 @@ import time
 import logging
 
 from typing import Callable, Optional, Sequence, Tuple, Union
+
 from rich.console import Console
+
 import numpy as np
 import torch
 

--- a/rlmeta/core/rescalers.py
+++ b/rlmeta/core/rescalers.py
@@ -160,10 +160,34 @@ class StdRescaler(Rescaler):
             x * self._running_moments.std(self._ddof, self._eps)).to(x.dtype)
 
 
-class SqrtRescaler(Rescaler):
+# class SqrtRescaler(Rescaler):
+#     """
+#     Introduced by R2D2 paper.
+#     https://openreview.net/pdf?id=r1lyTjAqYX
+#     """
+#
+#     def __init__(self, eps: float = 1e-3) -> None:
+#         super().__init__()
+#         self._eps = eps
+#
+#     @property
+#     def eps(self) -> float:
+#         return self._eps
+#
+#     def rescale(self, x: torch.Tensor) -> torch.Tensor:
+#         return x.sign() * ((x.abs() + 1.0).sqrt() - 1.0) + self.eps * x
+#
+#     def recover(self, x: torch.Tensor) -> torch.Tensor:
+#         if self._eps == 0.0:
+#             return x.sign() * (x.square() + 2.0 * x.abs())
+#         r = ((1.0 + 4.0 * self.eps *
+#               (x.abs() + 1.0 + self.eps)).sqrt() - 1.0) / (2.0 * self.eps)
+#         return x.sign() * (r.square() - 1.0)
+
+
+class SignedHyperbolicRescaler(Rescaler):
     """
-    Introduced by R2D2 paper.
-    https://openreview.net/pdf?id=r1lyTjAqYX
+    Transformed Bellman Operator in https://arxiv.org/abs/1805.11593.
     """
 
     def __init__(self, eps: float = 1e-3) -> None:

--- a/rlmeta/core/rescalers.py
+++ b/rlmeta/core/rescalers.py
@@ -160,31 +160,6 @@ class StdRescaler(Rescaler):
             x * self._running_moments.std(self._ddof, self._eps)).to(x.dtype)
 
 
-# class SqrtRescaler(Rescaler):
-#     """
-#     Introduced by R2D2 paper.
-#     https://openreview.net/pdf?id=r1lyTjAqYX
-#     """
-#
-#     def __init__(self, eps: float = 1e-3) -> None:
-#         super().__init__()
-#         self._eps = eps
-#
-#     @property
-#     def eps(self) -> float:
-#         return self._eps
-#
-#     def rescale(self, x: torch.Tensor) -> torch.Tensor:
-#         return x.sign() * ((x.abs() + 1.0).sqrt() - 1.0) + self.eps * x
-#
-#     def recover(self, x: torch.Tensor) -> torch.Tensor:
-#         if self._eps == 0.0:
-#             return x.sign() * (x.square() + 2.0 * x.abs())
-#         r = ((1.0 + 4.0 * self.eps *
-#               (x.abs() + 1.0 + self.eps)).sqrt() - 1.0) / (2.0 * self.eps)
-#         return x.sign() * (r.square() - 1.0)
-
-
 class SignedHyperbolicRescaler(Rescaler):
     """
     Transformed Bellman Operator in https://arxiv.org/abs/1805.11593.

--- a/rlmeta/envs/atari_wrapper.py
+++ b/rlmeta/envs/atari_wrapper.py
@@ -22,7 +22,7 @@ def make_atari_env(
         game: str,
         mode: Optional[int] = None,
         difficulty: Optional[int] = None,
-        repeat_action_probability: float = 0.0,  # v4
+        repeat_action_probability: float = 0.25,  # sticky actions
         full_action_space: bool = False,
         max_num_frames_per_episode: Optional[int] = None,
         render_mode: Optional[str] = None,

--- a/rlmeta/utils/running_stats.py
+++ b/rlmeta/utils/running_stats.py
@@ -105,6 +105,9 @@ class RunningMoments(nn.Module):
 
 
 class RunningTDError(nn.Module):
+    """
+    Running TD Error estimation introduced by https://arxiv.org/abs/2105.05347
+    """
 
     def __init__(self,
                  size: Union[int, Tuple[int]],


### PR DESCRIPTION
This PR introduced several improvements for Ape-X DQN listed below.
1. Use pre-computed q-value to compute priority. This is mentioned in the original Ape-X paper https://arxiv.org/abs/1803.00933
2. Add functional regularization from https://arxiv.org/abs/2106.02613
3. Add SpetralNorm from https://arxiv.org/abs/2105.05246
4. Modify default configs.